### PR TITLE
Rook Reference Classes break on `onHeaders`

### DIFF
--- a/R/httpuv.R
+++ b/R/httpuv.R
@@ -152,10 +152,24 @@ AppWrapper <- setRefClass(
         .app <<- app
     },
     onHeaders = function(req) {
-      if (is.null(.app$onHeaders))
-        return(NULL)
+      if (is.list(.app)) {
+        if (is.null(.app$onHeaders))
+          return(NULL)
 
-      rookCall(.app$onHeaders, req)
+        rookCall(.app$onHeaders, req)
+      } else {
+        refdef <- getRefClass(class(.app))
+        if ("onHeaders" %in% refdef$methods()) {
+          rookCall(.app$onHeaders, req)
+        } else if ("onHeaders" %in% names(refdef$fields())) {
+          if (is.null(.app$onHeaders))
+            return(NULL)
+
+          rookCall(.app$onHeaders, req)
+        } else {
+          return(NULL)
+        }
+      }
     },
     onBodyData = function(req, bytes) {
       if (is.null(req$.bodyData))


### PR DESCRIPTION
Hi,

I've written a fix for a situation I ran into where a reference class-based app would break.

What was happening was there was a check for `NULL`, and because there is no field or method present in the Reference Class, an error is returned.

A simple app that breaks follows:

``` r
Builder$new(
    Static$new(urls = c('/js', '/css'),
               root = '.'),
    Brewery$new(url = '/brew',
               root = '.'),
    Redirect$new("/brew/index.html"))
```

I'm not sure if my fix is suitable but I figure it's better than nothing :).
