### PR TITLE
with Depends: on Rcpp (>= 0.11.0) we can remove Rscript calls...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Sample .travis.yml for R projects.
 #
 # See https://github.com/craigcitro/r-travis/wiki
+# for documentation, examples and more
 
 language: c
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # Sample .travis.yml for R projects.
 #
-# See the r-travis repo and its wiki 
-# at https://github.com/craigcitro/r-travis/wiki
+# See https://github.com/craigcitro/r-travis/wiki
 
 language: c
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+# Sample .travis.yml for R projects.
+#
+# See the r-travis repo and its wiki 
+# at https://github.com/craigcitro/r-travis/wiki
+
+language: c
+
+env:
+  global:
+    - R_BUILD_ARGS="--no-build-vignettes --no-manual"
+    - R_CHECK_ARGS="--no-build-vignettes --no-manual --as-cran"
+
+before_install:
+  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
+  - chmod 755 ./travis-tool.sh
+  - ./travis-tool.sh bootstrap
+
+install:
+  - ./travis-tool.sh install_r Rcpp
+
+script: 
+  - ./travis-tool.sh run_tests
+
+after_failure:
+  - ./travis-tool.sh dump_logs
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+
+

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,3 @@
-## Use the R_HOME indirection to support installations of multiple R version
 
 UNAME := $(shell uname)
 
@@ -6,7 +5,7 @@ ifeq ($(UNAME), Darwin)
 FRAMEWORK = -framework CoreServices
 endif
 
-PKG_LIBS = `$(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()"` ./libuv/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o $(FRAMEWORK)
+PKG_LIBS = ./libuv/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o $(FRAMEWORK)
 ifeq ($(UNAME), SunOS)
 PKG_LIBS += -lkstat -lsendfile
 endif

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,6 +1,5 @@
 
-## Use the R_HOME indirection to support installations of multiple R version
-PKG_LIBS = $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "Rcpp:::LdFlags()") ./libuv/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o -lWs2_32 -lkernel32 -lpsapi -liphlpapi
+PKG_LIBS = ./libuv/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o -lWs2_32 -lkernel32 -lpsapi -liphlpapi
 
 PKG_CPPFLAGS += -I./libuv/include -I./http-parser -I./sha1 -I./base64 -D_WIN32_WINNT=0x0600
 CFLAGS += -D_WIN32_WINNT=0x0600


### PR DESCRIPTION
... from src/Makevars{,.win}

Your just-uploaded-to-CRAN version 1.2.3 has the Depends on "Rcpp (>= 0.11.0)". Which is really needed given that we no longer have a library to link against. So you may as well take advantage of this: this pull requests removes the now spurious call to Rscript to ask Rcpp about the library location and name. Because with Rcpp (>= 0.11.0) you only get an empty string back anyway.
