### PR TITLE
Send errors as UTF-8

### DIFF
--- a/R/httpuv.R
+++ b/R/httpuv.R
@@ -130,10 +130,11 @@ rookCall <- function(func, req, data = NULL, dataLength = -1) {
     return(list(
       status=500L,
       headers=list(
-        'Content-Type'='text/plain'
+        'Content-Type'='text/plain; charset=UTF-8'
       ),
-      body=charToRaw(
-        paste("ERROR:", attr(result, "condition")$message, collapse="\n"))
+      body=charToRaw(enc2utf8(
+        paste("ERROR:", attr(result, "condition")$message, collapse="\n")
+      ))
     ))
   } else {
     return(result)


### PR DESCRIPTION
This fixes rstudio/shiny#736. This is what it looks like in the browser now:

![image](https://cloud.githubusercontent.com/assets/86978/6514859/33b9feb0-c34b-11e4-9064-270144853697.png)
