### PR TITLE
add -lkvm for freebsd

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -10,6 +10,9 @@ PKG_LIBS = `$(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()"` ./libuv/libuv.a ./http-
 ifeq ($(UNAME), SunOS)
 PKG_LIBS += -lkstat -lsendfile
 endif
+ifeq ($(UNAME), FreeBSD)
+PKG_LIBS += -lkvm
+endif
 
 PKG_CPPFLAGS = -I./libuv/include -I./http-parser -I./sha1 -I./base64
 


### PR DESCRIPTION
On FreeBSD kvm_open is in shared library libkvm. Hence I propose the following trivial change. Thanks.