### PR TITLE
Don't add Content-Length header if already present

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: httpuv
 Type: Package
 Title: HTTP and WebSocket server library
-Version: 1.3.2.9000
+Version: 1.3.2.9001
 Date: 2014-10-22
 Author: RStudio, Inc.
 Copyright: RStudio, Inc.; Joyent, Inc.; Nginx Inc.; Igor Sysoev; Niels Provos;

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,9 @@ httpuv 1.3.2.9000
 
 * Error messages are now sent as UTF-8.
 
+* httpuv no longer adds a Content-Length header if one has already been
+  provided. This is for Shiny issue #876.
+
 httpuv 1.3.2
 ------------------------------------------------------------------------
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -9,13 +9,11 @@ using namespace Rcpp;
 void sendWSMessage(std::string conn, bool binary, Rcpp::RObject message);
 RcppExport SEXP httpuv_sendWSMessage(SEXP connSEXP, SEXP binarySEXP, SEXP messageSEXP) {
 BEGIN_RCPP
-    {
-        Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< std::string >::type conn(connSEXP );
-        Rcpp::traits::input_parameter< bool >::type binary(binarySEXP );
-        Rcpp::traits::input_parameter< Rcpp::RObject >::type message(messageSEXP );
-        sendWSMessage(conn, binary, message);
-    }
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< std::string >::type conn(connSEXP);
+    Rcpp::traits::input_parameter< bool >::type binary(binarySEXP);
+    Rcpp::traits::input_parameter< Rcpp::RObject >::type message(messageSEXP);
+    sendWSMessage(conn, binary, message);
     return R_NilValue;
 END_RCPP
 }
@@ -23,11 +21,9 @@ END_RCPP
 void closeWS(std::string conn);
 RcppExport SEXP httpuv_closeWS(SEXP connSEXP) {
 BEGIN_RCPP
-    {
-        Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< std::string >::type conn(connSEXP );
-        closeWS(conn);
-    }
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< std::string >::type conn(connSEXP);
+    closeWS(conn);
     return R_NilValue;
 END_RCPP
 }
@@ -35,55 +31,45 @@ END_RCPP
 Rcpp::RObject makeTcpServer(const std::string& host, int port, Rcpp::Function onHeaders, Rcpp::Function onBodyData, Rcpp::Function onRequest, Rcpp::Function onWSOpen, Rcpp::Function onWSMessage, Rcpp::Function onWSClose);
 RcppExport SEXP httpuv_makeTcpServer(SEXP hostSEXP, SEXP portSEXP, SEXP onHeadersSEXP, SEXP onBodyDataSEXP, SEXP onRequestSEXP, SEXP onWSOpenSEXP, SEXP onWSMessageSEXP, SEXP onWSCloseSEXP) {
 BEGIN_RCPP
-    SEXP __sexp_result;
-    {
-        Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< const std::string& >::type host(hostSEXP );
-        Rcpp::traits::input_parameter< int >::type port(portSEXP );
-        Rcpp::traits::input_parameter< Rcpp::Function >::type onHeaders(onHeadersSEXP );
-        Rcpp::traits::input_parameter< Rcpp::Function >::type onBodyData(onBodyDataSEXP );
-        Rcpp::traits::input_parameter< Rcpp::Function >::type onRequest(onRequestSEXP );
-        Rcpp::traits::input_parameter< Rcpp::Function >::type onWSOpen(onWSOpenSEXP );
-        Rcpp::traits::input_parameter< Rcpp::Function >::type onWSMessage(onWSMessageSEXP );
-        Rcpp::traits::input_parameter< Rcpp::Function >::type onWSClose(onWSCloseSEXP );
-        Rcpp::RObject __result = makeTcpServer(host, port, onHeaders, onBodyData, onRequest, onWSOpen, onWSMessage, onWSClose);
-        PROTECT(__sexp_result = Rcpp::wrap(__result));
-    }
-    UNPROTECT(1);
-    return __sexp_result;
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const std::string& >::type host(hostSEXP);
+    Rcpp::traits::input_parameter< int >::type port(portSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Function >::type onHeaders(onHeadersSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Function >::type onBodyData(onBodyDataSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Function >::type onRequest(onRequestSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Function >::type onWSOpen(onWSOpenSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Function >::type onWSMessage(onWSMessageSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Function >::type onWSClose(onWSCloseSEXP);
+    __result = Rcpp::wrap(makeTcpServer(host, port, onHeaders, onBodyData, onRequest, onWSOpen, onWSMessage, onWSClose));
+    return __result;
 END_RCPP
 }
 // makePipeServer
 Rcpp::RObject makePipeServer(const std::string& name, int mask, Rcpp::Function onHeaders, Rcpp::Function onBodyData, Rcpp::Function onRequest, Rcpp::Function onWSOpen, Rcpp::Function onWSMessage, Rcpp::Function onWSClose);
 RcppExport SEXP httpuv_makePipeServer(SEXP nameSEXP, SEXP maskSEXP, SEXP onHeadersSEXP, SEXP onBodyDataSEXP, SEXP onRequestSEXP, SEXP onWSOpenSEXP, SEXP onWSMessageSEXP, SEXP onWSCloseSEXP) {
 BEGIN_RCPP
-    SEXP __sexp_result;
-    {
-        Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< const std::string& >::type name(nameSEXP );
-        Rcpp::traits::input_parameter< int >::type mask(maskSEXP );
-        Rcpp::traits::input_parameter< Rcpp::Function >::type onHeaders(onHeadersSEXP );
-        Rcpp::traits::input_parameter< Rcpp::Function >::type onBodyData(onBodyDataSEXP );
-        Rcpp::traits::input_parameter< Rcpp::Function >::type onRequest(onRequestSEXP );
-        Rcpp::traits::input_parameter< Rcpp::Function >::type onWSOpen(onWSOpenSEXP );
-        Rcpp::traits::input_parameter< Rcpp::Function >::type onWSMessage(onWSMessageSEXP );
-        Rcpp::traits::input_parameter< Rcpp::Function >::type onWSClose(onWSCloseSEXP );
-        Rcpp::RObject __result = makePipeServer(name, mask, onHeaders, onBodyData, onRequest, onWSOpen, onWSMessage, onWSClose);
-        PROTECT(__sexp_result = Rcpp::wrap(__result));
-    }
-    UNPROTECT(1);
-    return __sexp_result;
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const std::string& >::type name(nameSEXP);
+    Rcpp::traits::input_parameter< int >::type mask(maskSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Function >::type onHeaders(onHeadersSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Function >::type onBodyData(onBodyDataSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Function >::type onRequest(onRequestSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Function >::type onWSOpen(onWSOpenSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Function >::type onWSMessage(onWSMessageSEXP);
+    Rcpp::traits::input_parameter< Rcpp::Function >::type onWSClose(onWSCloseSEXP);
+    __result = Rcpp::wrap(makePipeServer(name, mask, onHeaders, onBodyData, onRequest, onWSOpen, onWSMessage, onWSClose));
+    return __result;
 END_RCPP
 }
 // destroyServer
 void destroyServer(std::string handle);
 RcppExport SEXP httpuv_destroyServer(SEXP handleSEXP) {
 BEGIN_RCPP
-    {
-        Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< std::string >::type handle(handleSEXP );
-        destroyServer(handle);
-    }
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< std::string >::type handle(handleSEXP);
+    destroyServer(handle);
     return R_NilValue;
 END_RCPP
 }
@@ -91,25 +77,19 @@ END_RCPP
 bool run(uint32_t timeoutMillis);
 RcppExport SEXP httpuv_run(SEXP timeoutMillisSEXP) {
 BEGIN_RCPP
-    SEXP __sexp_result;
-    {
-        Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< uint32_t >::type timeoutMillis(timeoutMillisSEXP );
-        bool __result = run(timeoutMillis);
-        PROTECT(__sexp_result = Rcpp::wrap(__result));
-    }
-    UNPROTECT(1);
-    return __sexp_result;
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< uint32_t >::type timeoutMillis(timeoutMillisSEXP);
+    __result = Rcpp::wrap(run(timeoutMillis));
+    return __result;
 END_RCPP
 }
 // stopLoop
 void stopLoop();
 RcppExport SEXP httpuv_stopLoop() {
 BEGIN_RCPP
-    {
-        Rcpp::RNGScope __rngScope;
-        stopLoop();
-    }
+    Rcpp::RNGScope __rngScope;
+    stopLoop();
     return R_NilValue;
 END_RCPP
 }
@@ -117,41 +97,31 @@ END_RCPP
 std::string base64encode(const Rcpp::RawVector& x);
 RcppExport SEXP httpuv_base64encode(SEXP xSEXP) {
 BEGIN_RCPP
-    SEXP __sexp_result;
-    {
-        Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type x(xSEXP );
-        std::string __result = base64encode(x);
-        PROTECT(__sexp_result = Rcpp::wrap(__result));
-    }
-    UNPROTECT(1);
-    return __sexp_result;
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type x(xSEXP);
+    __result = Rcpp::wrap(base64encode(x));
+    return __result;
 END_RCPP
 }
 // daemonize
 Rcpp::RObject daemonize(std::string handle);
 RcppExport SEXP httpuv_daemonize(SEXP handleSEXP) {
 BEGIN_RCPP
-    SEXP __sexp_result;
-    {
-        Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< std::string >::type handle(handleSEXP );
-        Rcpp::RObject __result = daemonize(handle);
-        PROTECT(__sexp_result = Rcpp::wrap(__result));
-    }
-    UNPROTECT(1);
-    return __sexp_result;
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< std::string >::type handle(handleSEXP);
+    __result = Rcpp::wrap(daemonize(handle));
+    return __result;
 END_RCPP
 }
 // destroyDaemonizedServer
 void destroyDaemonizedServer(std::string handle);
 RcppExport SEXP httpuv_destroyDaemonizedServer(SEXP handleSEXP) {
 BEGIN_RCPP
-    {
-        Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< std::string >::type handle(handleSEXP );
-        destroyDaemonizedServer(handle);
-    }
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< std::string >::type handle(handleSEXP);
+    destroyDaemonizedServer(handle);
     return R_NilValue;
 END_RCPP
 }
@@ -159,59 +129,43 @@ END_RCPP
 std::vector<std::string> encodeURI(std::vector<std::string> value);
 RcppExport SEXP httpuv_encodeURI(SEXP valueSEXP) {
 BEGIN_RCPP
-    SEXP __sexp_result;
-    {
-        Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< std::vector<std::string> >::type value(valueSEXP );
-        std::vector<std::string> __result = encodeURI(value);
-        PROTECT(__sexp_result = Rcpp::wrap(__result));
-    }
-    UNPROTECT(1);
-    return __sexp_result;
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type value(valueSEXP);
+    __result = Rcpp::wrap(encodeURI(value));
+    return __result;
 END_RCPP
 }
 // encodeURIComponent
 std::vector<std::string> encodeURIComponent(std::vector<std::string> value);
 RcppExport SEXP httpuv_encodeURIComponent(SEXP valueSEXP) {
 BEGIN_RCPP
-    SEXP __sexp_result;
-    {
-        Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< std::vector<std::string> >::type value(valueSEXP );
-        std::vector<std::string> __result = encodeURIComponent(value);
-        PROTECT(__sexp_result = Rcpp::wrap(__result));
-    }
-    UNPROTECT(1);
-    return __sexp_result;
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type value(valueSEXP);
+    __result = Rcpp::wrap(encodeURIComponent(value));
+    return __result;
 END_RCPP
 }
 // decodeURI
 std::vector<std::string> decodeURI(std::vector<std::string> value);
 RcppExport SEXP httpuv_decodeURI(SEXP valueSEXP) {
 BEGIN_RCPP
-    SEXP __sexp_result;
-    {
-        Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< std::vector<std::string> >::type value(valueSEXP );
-        std::vector<std::string> __result = decodeURI(value);
-        PROTECT(__sexp_result = Rcpp::wrap(__result));
-    }
-    UNPROTECT(1);
-    return __sexp_result;
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type value(valueSEXP);
+    __result = Rcpp::wrap(decodeURI(value));
+    return __result;
 END_RCPP
 }
 // decodeURIComponent
 std::vector<std::string> decodeURIComponent(std::vector<std::string> value);
 RcppExport SEXP httpuv_decodeURIComponent(SEXP valueSEXP) {
 BEGIN_RCPP
-    SEXP __sexp_result;
-    {
-        Rcpp::RNGScope __rngScope;
-        Rcpp::traits::input_parameter< std::vector<std::string> >::type value(valueSEXP );
-        std::vector<std::string> __result = decodeURIComponent(value);
-        PROTECT(__sexp_result = Rcpp::wrap(__result));
-    }
-    UNPROTECT(1);
-    return __sexp_result;
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type value(valueSEXP);
+    __result = Rcpp::wrap(decodeURIComponent(value));
+    return __result;
 END_RCPP
 }

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -392,13 +392,21 @@ void HttpResponse::writeResponse() {
   // TODO: Optimize
   std::ostringstream response(std::ios_base::binary);
   response << "HTTP/1.1 " << _statusCode << " " << _status << "\r\n";
+  bool hasContentLengthHeader = false;
   for (ResponseHeaders::const_iterator it = _headers.begin();
      it != _headers.end();
      it++) {
     response << it->first << ": " << it->second << "\r\n";
+
+    if (it->first == "Content-Length") {
+      hasContentLengthHeader = true;
+    }
   }
-  if (_pBody)
+
+  if (_pBody && !hasContentLengthHeader) {
     response << "Content-Length: " << _pBody->size() << "\r\n";
+  }
+
   response << "\r\n";
   std::string responseStr = response.str();
   _responseHeader.assign(responseStr.begin(), responseStr.end());

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -398,7 +398,7 @@ void HttpResponse::writeResponse() {
      it++) {
     response << it->first << ": " << it->second << "\r\n";
 
-    if (it->first == "Content-Length") {
+    if (strcasecmp(it->first.c_str(), "Content-Length") == 0) {
       hasContentLengthHeader = true;
     }
   }


### PR DESCRIPTION
This is to support rstudio/shiny#876.

The `RcppExports.cpp` file had a lot of changes - perhaps because I built this with a newer version of Rcpp (0.11.6)?