### PR TITLE
Allow creating a TCP server using an ipv6 address

### DIFF
--- a/src/http.cpp
+++ b/src/http.cpp
@@ -593,8 +593,14 @@ uv_stream_t* createTcpServer(uv_loop_t* pLoop, const std::string& host,
   pSocket->handle.stream.data = pSocket;
   pSocket->pWebApplication = pWebApplication;
 
-  struct sockaddr_in address = uv_ip4_addr(host.c_str(), port);
-  int r = uv_tcp_bind(&pSocket->handle.tcp, address);
+  int r = 1;
+  if (ipFamily(host) == AF_INET6) {
+    struct sockaddr_in6 address = uv_ip6_addr(host.c_str(), port);
+    r = uv_tcp_bind6(&pSocket->handle.tcp, address);
+  } else {
+    struct sockaddr_in address = uv_ip4_addr(host.c_str(), port);
+    r = uv_tcp_bind(&pSocket->handle.tcp, address);
+  }
   if (r) {
     pSocket->destroy();
     return NULL;

--- a/src/uvutil.h
+++ b/src/uvutil.h
@@ -21,6 +21,15 @@ inline uv_stream_t* toStream(uv_tcp_t* tcp) {
   return (uv_stream_t*)tcp;
 }
 
+inline int ipFamily(const std::string& ip) {
+  struct sockaddr_in sa;
+  uv_err_t result = uv_inet_pton(AF_INET6, ip.c_str(), &(sa.sin_addr));
+  if (result.code == UV_OK) {
+    return AF_INET6;
+  }
+  return AF_INET;
+}
+
 void throwLastError(uv_loop_t* pLoop,
   const std::string& prefix = std::string(),
   const std::string& suffix = std::string());


### PR DESCRIPTION
For ipv6-only setups, we need to be able to pass ipv6 addresses as the
host (e.g. '::') argument to httpuv::startServer().

Not sure if this is the right approach, I'd love to get your feedback.
