### PR TITLE
Gifi patch 1

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -6,7 +6,7 @@ ifeq ($(UNAME), Darwin)
 FRAMEWORK = -framework CoreServices
 endif
 
-PKG_LIBS = `$(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()"` ./libuv/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o $(FRAMEWORK)
+PKG_LIBS = ./libuv/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o $(FRAMEWORK)
 ifeq ($(UNAME), SunOS)
 PKG_LIBS += -lkstat -lsendfile
 endif

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,6 +1,6 @@
 
 ## Use the R_HOME indirection to support installations of multiple R version
-PKG_LIBS = $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "Rcpp:::LdFlags()") ./libuv/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o -lWs2_32 -lkernel32 -lpsapi -liphlpapi
+PKG_LIBS = ./libuv/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o -lWs2_32 -lkernel32 -lpsapi -liphlpapi
 
 PKG_CPPFLAGS += -I./libuv/include -I./http-parser -I./sha1 -I./base64 -D_WIN32_WINNT=0x0600
 CFLAGS += -D_WIN32_WINNT=0x0600


### PR DESCRIPTION
When installing from sources, the PR fixes errors like
```
g++: error: >: No such file or directory
g++: error: Rcpp:::LdFlags(): No such file or directory
g++: error: >: No such file or directory
g++: error: >: No such file or directory
```
when an R startup script has ```cat()```.

This will fix #47.