### PR TITLE
Support httpuv::service(NA) for non-blocking run

### DIFF
--- a/R/httpuv.R
+++ b/R/httpuv.R
@@ -397,7 +397,7 @@ startPipeServer <- function(name, mask, app) {
 #' 
 #' @param timeoutMs Approximate number of milliseconds to run before returning. 
 #'   If 0, then the function will continually process requests without returning
-#'   unless an error occurs.
+#'   unless an error occurs. If NA, performs a non-blocking run without waiting.
 #'
 #' @examples
 #' \dontrun{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -74,12 +74,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // run
-bool run(uint32_t timeoutMillis);
+bool run(int timeoutMillis);
 RcppExport SEXP httpuv_run(SEXP timeoutMillisSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
-    Rcpp::traits::input_parameter< uint32_t >::type timeoutMillis(timeoutMillisSEXP);
+    Rcpp::traits::input_parameter< int >::type timeoutMillis(timeoutMillisSEXP);
     __result = Rcpp::wrap(run(timeoutMillis));
     return __result;
 END_RCPP

--- a/src/httpuv.cpp
+++ b/src/httpuv.cpp
@@ -379,7 +379,7 @@ void stop_loop_timer_cb(uv_timer_t* handle, int status) {
 
 // Run the libuv default loop for roughly timeoutMillis, then stop
 // [[Rcpp::export]]
-bool run(uint32_t timeoutMillis) {
+bool run(int timeoutMillis) {
   static uv_timer_t timer_req = {0};
   int r;
 
@@ -405,7 +405,7 @@ bool run(uint32_t timeoutMillis) {
 #ifndef _WIN32
   signal(SIGPIPE, SIG_IGN);
 #endif
-  return uv_run(uv_default_loop(), UV_RUN_ONCE);
+  return uv_run(uv_default_loop(), timeoutMillis == NA_INTEGER ? UV_RUN_NOWAIT : UV_RUN_ONCE);
 }
 
 // [[Rcpp::export]]


### PR DESCRIPTION
This adds support for performing a non-blocking run `UV_RUN_NOWAIT ` via:

```r
httpuv::service(NA)
```
The implementation is trivial, but unfortunately `httpuv::service(0)` was already taken to mean "no timeout" instead of "zero timeout". Therefore this uses `NA` for this purpose.


