### PR TITLE
Update to Rcpp 0.12.12

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2,43 +2,43 @@
 # Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 sendWSMessage <- function(conn, binary, message) {
-    invisible(.Call('httpuv_sendWSMessage', PACKAGE = 'httpuv', conn, binary, message))
+    invisible(.Call('_httpuv_sendWSMessage', PACKAGE = 'httpuv', conn, binary, message))
 }
 
 closeWS <- function(conn) {
-    invisible(.Call('httpuv_closeWS', PACKAGE = 'httpuv', conn))
+    invisible(.Call('_httpuv_closeWS', PACKAGE = 'httpuv', conn))
 }
 
 makeTcpServer <- function(host, port, onHeaders, onBodyData, onRequest, onWSOpen, onWSMessage, onWSClose) {
-    .Call('httpuv_makeTcpServer', PACKAGE = 'httpuv', host, port, onHeaders, onBodyData, onRequest, onWSOpen, onWSMessage, onWSClose)
+    .Call('_httpuv_makeTcpServer', PACKAGE = 'httpuv', host, port, onHeaders, onBodyData, onRequest, onWSOpen, onWSMessage, onWSClose)
 }
 
 makePipeServer <- function(name, mask, onHeaders, onBodyData, onRequest, onWSOpen, onWSMessage, onWSClose) {
-    .Call('httpuv_makePipeServer', PACKAGE = 'httpuv', name, mask, onHeaders, onBodyData, onRequest, onWSOpen, onWSMessage, onWSClose)
+    .Call('_httpuv_makePipeServer', PACKAGE = 'httpuv', name, mask, onHeaders, onBodyData, onRequest, onWSOpen, onWSMessage, onWSClose)
 }
 
 destroyServer <- function(handle) {
-    invisible(.Call('httpuv_destroyServer', PACKAGE = 'httpuv', handle))
+    invisible(.Call('_httpuv_destroyServer', PACKAGE = 'httpuv', handle))
 }
 
 run <- function(timeoutMillis) {
-    .Call('httpuv_run', PACKAGE = 'httpuv', timeoutMillis)
+    .Call('_httpuv_run', PACKAGE = 'httpuv', timeoutMillis)
 }
 
 stopLoop <- function() {
-    invisible(.Call('httpuv_stopLoop', PACKAGE = 'httpuv'))
+    invisible(.Call('_httpuv_stopLoop', PACKAGE = 'httpuv'))
 }
 
 base64encode <- function(x) {
-    .Call('httpuv_base64encode', PACKAGE = 'httpuv', x)
+    .Call('_httpuv_base64encode', PACKAGE = 'httpuv', x)
 }
 
 daemonize <- function(handle) {
-    .Call('httpuv_daemonize', PACKAGE = 'httpuv', handle)
+    .Call('_httpuv_daemonize', PACKAGE = 'httpuv', handle)
 }
 
 destroyDaemonizedServer <- function(handle) {
-    invisible(.Call('httpuv_destroyDaemonizedServer', PACKAGE = 'httpuv', handle))
+    invisible(.Call('_httpuv_destroyDaemonizedServer', PACKAGE = 'httpuv', handle))
 }
 
 #' URI encoding/decoding
@@ -72,25 +72,25 @@ destroyDaemonizedServer <- function(handle) {
 #'
 #' @export
 encodeURI <- function(value) {
-    .Call('httpuv_encodeURI', PACKAGE = 'httpuv', value)
+    .Call('_httpuv_encodeURI', PACKAGE = 'httpuv', value)
 }
 
 #' @rdname encodeURI
 #' @export
 encodeURIComponent <- function(value) {
-    .Call('httpuv_encodeURIComponent', PACKAGE = 'httpuv', value)
+    .Call('_httpuv_encodeURIComponent', PACKAGE = 'httpuv', value)
 }
 
 #' @rdname encodeURI
 #' @export
 decodeURI <- function(value) {
-    .Call('httpuv_decodeURI', PACKAGE = 'httpuv', value)
+    .Call('_httpuv_decodeURI', PACKAGE = 'httpuv', value)
 }
 
 #' @rdname encodeURI
 #' @export
 decodeURIComponent <- function(value) {
-    .Call('httpuv_decodeURIComponent', PACKAGE = 'httpuv', value)
+    .Call('_httpuv_decodeURIComponent', PACKAGE = 'httpuv', value)
 }
 
 #' Apply the value of .Random.seed to R's internal RNG state
@@ -104,6 +104,6 @@ decodeURIComponent <- function(value) {
 #' @keywords internal
 #' @export
 getRNGState <- function() {
-    invisible(.Call('httpuv_getRNGState', PACKAGE = 'httpuv'))
+    invisible(.Call('_httpuv_getRNGState', PACKAGE = 'httpuv'))
 }
 

--- a/src/RcppExports-legacy.cpp
+++ b/src/RcppExports-legacy.cpp
@@ -1,0 +1,36 @@
+// This file is unfortunately needed because Shiny 1.0.5 and below included a
+// copy of httpuv::decodeURIComponent. With httpuv 1.3.5 and below, this was
+// defined as:
+// function (value) {
+//   .Call("httpuv_decodeURIComponent", PACKAGE = "httpuv", value)
+// }
+//
+// However, later versions of httpuv were built with Rcpp 0.12.12, which
+// changed the name of the C function to "_httpuv_decodeURIComponent". The
+// result is that if Shiny 1.0.5 was built with httpuv 1.3.5 but run with a
+// newer version of httpuv, it would try to call out to a nonexistent C
+// function named "httpuv_decodeURIComponent". The function below is a copy of
+// _httpuv_decodeURIComponent, but with the old name. It preserves backward
+// compatibility, so that Shiny 1.0.5 (and older) built with httpuv 1.3.5 (and
+// older) would be able to run with newer versions of httpuv.
+//
+// This issue was fixed with Shiny 1.0.6:
+// https://github.com/rstudio/shiny/commit/dc18b20e5a9b8b2b74a49f44c920f5159801d147
+//
+// It will probably be safe to remove this after Shiny 1.0.6 has been out for
+// a year or so.
+
+#include <Rcpp.h>
+
+using namespace Rcpp;
+
+std::vector<std::string> decodeURIComponent(std::vector<std::string> value);
+RcppExport SEXP httpuv_decodeURIComponent(SEXP valueSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type value(valueSEXP);
+    rcpp_result_gen = Rcpp::wrap(decodeURIComponent(value));
+    return rcpp_result_gen;
+END_RCPP
+}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -7,7 +7,7 @@ using namespace Rcpp;
 
 // sendWSMessage
 void sendWSMessage(std::string conn, bool binary, Rcpp::RObject message);
-RcppExport SEXP httpuv_sendWSMessage(SEXP connSEXP, SEXP binarySEXP, SEXP messageSEXP) {
+RcppExport SEXP _httpuv_sendWSMessage(SEXP connSEXP, SEXP binarySEXP, SEXP messageSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type conn(connSEXP);
@@ -19,7 +19,7 @@ END_RCPP
 }
 // closeWS
 void closeWS(std::string conn);
-RcppExport SEXP httpuv_closeWS(SEXP connSEXP) {
+RcppExport SEXP _httpuv_closeWS(SEXP connSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type conn(connSEXP);
@@ -29,7 +29,7 @@ END_RCPP
 }
 // makeTcpServer
 Rcpp::RObject makeTcpServer(const std::string& host, int port, Rcpp::Function onHeaders, Rcpp::Function onBodyData, Rcpp::Function onRequest, Rcpp::Function onWSOpen, Rcpp::Function onWSMessage, Rcpp::Function onWSClose);
-RcppExport SEXP httpuv_makeTcpServer(SEXP hostSEXP, SEXP portSEXP, SEXP onHeadersSEXP, SEXP onBodyDataSEXP, SEXP onRequestSEXP, SEXP onWSOpenSEXP, SEXP onWSMessageSEXP, SEXP onWSCloseSEXP) {
+RcppExport SEXP _httpuv_makeTcpServer(SEXP hostSEXP, SEXP portSEXP, SEXP onHeadersSEXP, SEXP onBodyDataSEXP, SEXP onRequestSEXP, SEXP onWSOpenSEXP, SEXP onWSMessageSEXP, SEXP onWSCloseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -47,7 +47,7 @@ END_RCPP
 }
 // makePipeServer
 Rcpp::RObject makePipeServer(const std::string& name, int mask, Rcpp::Function onHeaders, Rcpp::Function onBodyData, Rcpp::Function onRequest, Rcpp::Function onWSOpen, Rcpp::Function onWSMessage, Rcpp::Function onWSClose);
-RcppExport SEXP httpuv_makePipeServer(SEXP nameSEXP, SEXP maskSEXP, SEXP onHeadersSEXP, SEXP onBodyDataSEXP, SEXP onRequestSEXP, SEXP onWSOpenSEXP, SEXP onWSMessageSEXP, SEXP onWSCloseSEXP) {
+RcppExport SEXP _httpuv_makePipeServer(SEXP nameSEXP, SEXP maskSEXP, SEXP onHeadersSEXP, SEXP onBodyDataSEXP, SEXP onRequestSEXP, SEXP onWSOpenSEXP, SEXP onWSMessageSEXP, SEXP onWSCloseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -65,7 +65,7 @@ END_RCPP
 }
 // destroyServer
 void destroyServer(std::string handle);
-RcppExport SEXP httpuv_destroyServer(SEXP handleSEXP) {
+RcppExport SEXP _httpuv_destroyServer(SEXP handleSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type handle(handleSEXP);
@@ -75,7 +75,7 @@ END_RCPP
 }
 // run
 bool run(int timeoutMillis);
-RcppExport SEXP httpuv_run(SEXP timeoutMillisSEXP) {
+RcppExport SEXP _httpuv_run(SEXP timeoutMillisSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -86,7 +86,7 @@ END_RCPP
 }
 // stopLoop
 void stopLoop();
-RcppExport SEXP httpuv_stopLoop() {
+RcppExport SEXP _httpuv_stopLoop() {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     stopLoop();
@@ -95,7 +95,7 @@ END_RCPP
 }
 // base64encode
 std::string base64encode(const Rcpp::RawVector& x);
-RcppExport SEXP httpuv_base64encode(SEXP xSEXP) {
+RcppExport SEXP _httpuv_base64encode(SEXP xSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -106,7 +106,7 @@ END_RCPP
 }
 // daemonize
 Rcpp::RObject daemonize(std::string handle);
-RcppExport SEXP httpuv_daemonize(SEXP handleSEXP) {
+RcppExport SEXP _httpuv_daemonize(SEXP handleSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -117,7 +117,7 @@ END_RCPP
 }
 // destroyDaemonizedServer
 void destroyDaemonizedServer(std::string handle);
-RcppExport SEXP httpuv_destroyDaemonizedServer(SEXP handleSEXP) {
+RcppExport SEXP _httpuv_destroyDaemonizedServer(SEXP handleSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type handle(handleSEXP);
@@ -127,7 +127,7 @@ END_RCPP
 }
 // encodeURI
 std::vector<std::string> encodeURI(std::vector<std::string> value);
-RcppExport SEXP httpuv_encodeURI(SEXP valueSEXP) {
+RcppExport SEXP _httpuv_encodeURI(SEXP valueSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -138,7 +138,7 @@ END_RCPP
 }
 // encodeURIComponent
 std::vector<std::string> encodeURIComponent(std::vector<std::string> value);
-RcppExport SEXP httpuv_encodeURIComponent(SEXP valueSEXP) {
+RcppExport SEXP _httpuv_encodeURIComponent(SEXP valueSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -149,7 +149,7 @@ END_RCPP
 }
 // decodeURI
 std::vector<std::string> decodeURI(std::vector<std::string> value);
-RcppExport SEXP httpuv_decodeURI(SEXP valueSEXP) {
+RcppExport SEXP _httpuv_decodeURI(SEXP valueSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -160,7 +160,7 @@ END_RCPP
 }
 // decodeURIComponent
 std::vector<std::string> decodeURIComponent(std::vector<std::string> value);
-RcppExport SEXP httpuv_decodeURIComponent(SEXP valueSEXP) {
+RcppExport SEXP _httpuv_decodeURIComponent(SEXP valueSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -171,7 +171,7 @@ END_RCPP
 }
 // getRNGState
 void getRNGState();
-RcppExport SEXP httpuv_getRNGState() {
+RcppExport SEXP _httpuv_getRNGState() {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     getRNGState();


### PR DESCRIPTION
The generated function names have changed with the latest version of Rcpp, 0.12.12, adding a `_` prefix.

One potential problem is that Shiny 1.0.5 and below had copied a function from httpuv, thereby embedding the name of a C function, `httpuv_decodeURIComponent`, at Shiny's build-time. Because the names of the function changed to `_httpuv_decodeURIComponent`with Rcpp 0.12.12, this would break Shiny. I worked around this by manually creating a function with the old name, `httpuv_decodeURIComponent`, identical to `_httpuv_decodeURIComponent`.
