### PR TITLE
Use Rcpp symbol registration and visibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: httpuv
 Type: Package
 Title: HTTP and WebSocket Server Library
-Version: 1.3.5
+Version: 1.3.5.9000
 Author: Joe Cheng, Hector Corrada Bravo [ctb], Jeroen Ooms [ctb],
     Winston Chang [ctb]
 Copyright: RStudio, Inc.; Joyent, Inc.; Nginx Inc.; Igor Sysoev; Niels Provos;

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+httpuv 1.3.6
+------------------------------------------------------------------------
+
+* Let Rcpp handle symbol registration
+
+* Hide internal symbols from shared library on supported platforms. This
+  reduces the risk of conflicts with other packages bundling libuv.
+  
 httpuv 1.3.5
 ------------------------------------------------------------------------
 

--- a/R/httpuv.R
+++ b/R/httpuv.R
@@ -564,3 +564,8 @@ startDaemonizedServer <- function(host, port, app) {
 stopDaemonizedServer <- function(server) {
   destroyDaemonizedServer(server)
 }
+
+# Needed so that Rcpp registers the 'httpuv_decodeURIComponent' symbol
+legacy_dummy <- function(value){
+  .Call(httpuv_decodeURIComponent, PACKAGE = "httpuv", value)
+}

--- a/src/Makevars
+++ b/src/Makevars
@@ -20,7 +20,7 @@ ifeq ($(UNAME), OpenBSD)
 PKG_LIBS += -lkvm
 endif
 
-PKG_CPPFLAGS = -I./libuv/include -I./http-parser -I./sha1 -I./base64
+PKG_CPPFLAGS = -I./libuv/include -I./http-parser -I./sha1 -I./base64 $(C_VISIBILITY)
 
 
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -22,26 +22,10 @@ endif
 
 PKG_CPPFLAGS = -I./libuv/include -I./http-parser -I./sha1 -I./base64 $(C_VISIBILITY)
 
+$(SHLIB): libuv/libuv.a http-parser/http_parser.o sha1/sha1.o base64/base64.o
 
-
-.PHONY: all libuv.a http-parser.o
-
-all: $(SHLIB)
-$(SHLIB): libuv.a http-parser.o sha1.o base64.o
-
-libuv.a:
+libuv/libuv.a:
 	$(MAKE) --directory=libuv \
-		CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS)" AR="$(AR)" RANLIB="$(RANLIB)" \
+		CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(C_VISIBILITY)" AR="$(AR)" RANLIB="$(RANLIB)" \
     HAVE_DTRACE=0 \
 		libuv.a
-
-http-parser.o:
-	$(MAKE) --directory=http-parser \
-		CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS)" AR="$(AR)" RANLIB="$(RANLIB)" \
-		http_parser.o
-
-sha1.o:
-	(cd sha1 && $(CC) $(CFLAGS) $(CPICFLAGS) -c sha1.c -o sha1.o)
-
-base64.o:
-	(cd base64 && $(CXX) $(ALL_CPPFLAGS) $(ALL_CXXFLAGS) -c base64.cpp -o base64.o)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -179,6 +179,8 @@ BEGIN_RCPP
 END_RCPP
 }
 
+RcppExport SEXP httpuv_decodeURIComponent(SEXP);
+
 static const R_CallMethodDef CallEntries[] = {
     {"_httpuv_sendWSMessage", (DL_FUNC) &_httpuv_sendWSMessage, 3},
     {"_httpuv_closeWS", (DL_FUNC) &_httpuv_closeWS, 1},
@@ -195,6 +197,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_httpuv_decodeURI", (DL_FUNC) &_httpuv_decodeURI, 1},
     {"_httpuv_decodeURIComponent", (DL_FUNC) &_httpuv_decodeURIComponent, 1},
     {"_httpuv_getRNGState", (DL_FUNC) &_httpuv_getRNGState, 0},
+    {"httpuv_decodeURIComponent",       (DL_FUNC) &httpuv_decodeURIComponent,       1},
     {NULL, NULL, 0}
 };
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -178,3 +178,27 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+
+static const R_CallMethodDef CallEntries[] = {
+    {"_httpuv_sendWSMessage", (DL_FUNC) &_httpuv_sendWSMessage, 3},
+    {"_httpuv_closeWS", (DL_FUNC) &_httpuv_closeWS, 1},
+    {"_httpuv_makeTcpServer", (DL_FUNC) &_httpuv_makeTcpServer, 8},
+    {"_httpuv_makePipeServer", (DL_FUNC) &_httpuv_makePipeServer, 8},
+    {"_httpuv_destroyServer", (DL_FUNC) &_httpuv_destroyServer, 1},
+    {"_httpuv_run", (DL_FUNC) &_httpuv_run, 1},
+    {"_httpuv_stopLoop", (DL_FUNC) &_httpuv_stopLoop, 0},
+    {"_httpuv_base64encode", (DL_FUNC) &_httpuv_base64encode, 1},
+    {"_httpuv_daemonize", (DL_FUNC) &_httpuv_daemonize, 1},
+    {"_httpuv_destroyDaemonizedServer", (DL_FUNC) &_httpuv_destroyDaemonizedServer, 1},
+    {"_httpuv_encodeURI", (DL_FUNC) &_httpuv_encodeURI, 1},
+    {"_httpuv_encodeURIComponent", (DL_FUNC) &_httpuv_encodeURIComponent, 1},
+    {"_httpuv_decodeURI", (DL_FUNC) &_httpuv_decodeURI, 1},
+    {"_httpuv_decodeURIComponent", (DL_FUNC) &_httpuv_decodeURIComponent, 1},
+    {"_httpuv_getRNGState", (DL_FUNC) &_httpuv_getRNGState, 0},
+    {NULL, NULL, 0}
+};
+
+RcppExport void R_init_httpuv(DllInfo *dll) {
+    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
+    R_useDynamicSymbols(dll, FALSE);
+}

--- a/src/register.c
+++ b/src/register.c
@@ -1,7 +1,0 @@
-#include <Rinternals.h>
-#include <R_ext/Rdynload.h>
-
-void R_init_httpuv(DllInfo* info) {
-  R_registerRoutines(info, NULL, NULL, NULL, NULL);
-  R_useDynamicSymbols(info, TRUE);
-}


### PR DESCRIPTION
Use the new automatic Rcpp symbol registration. Also compile with `-fvisibility=hidden` on linux to prevent conflicts with other packages using the same names. 