### PR TITLE
Call onHeaders asynchronously with later()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     later
 Remotes:
     rstudio/promises
-LinkingTo: Rcpp, BH
+LinkingTo: Rcpp, BH, later
 URL: https://github.com/rstudio/httpuv
 SystemRequirements: GNU make
 RoxygenNote: 6.0.1

--- a/src/http-parser/http_parser.c
+++ b/src/http-parser/http_parser.c
@@ -60,6 +60,7 @@ do {                                                                 \
 #define UPDATE_STATE(V) p_state = (enum state) (V);
 #define RETURN(V)                                                    \
 do {                                                                 \
+  parser->is_running = 0;                                            \
   parser->state = CURRENT_STATE();                                   \
   return (V);                                                        \
 } while (0);
@@ -339,6 +340,12 @@ enum state
   , s_chunk_size_almost_done
 
   , s_headers_almost_done
+
+  /* When the (async) on_headers function has been called but we're still
+   * waiting for a response. */
+  , s_wait_for_on_headers_completed
+  , s_on_headers_completed
+
   , s_headers_done
 
   /* Important: 's_headers_done' must be the last 'header' state. All
@@ -647,6 +654,13 @@ size_t http_parser_execute (http_parser *parser,
   enum state p_state = (enum state) parser->state;
   const unsigned int lenient = parser->lenient_http_headers;
 
+  /* Check for re-entrant calls to this function. */
+  if (parser->is_running) {
+    SET_ERRNO(HPE_REENTRANT_CALL);
+    goto error;
+  }
+  parser->is_running = 1;
+
   /* We're in an error state. Don't bother doing anything. */
   if (HTTP_PARSER_ERRNO(parser) != HPE_OK) {
     return 0;
@@ -706,6 +720,12 @@ size_t http_parser_execute (http_parser *parser,
       COUNT_HEADER_SIZE(1);
 
 reexecute:
+
+    /* Waiting for on_headers processing to finish. Don't do anything. */
+    if (CURRENT_STATE() == s_wait_for_on_headers_completed) {
+      RETURN(p - data);
+    }
+
     switch (CURRENT_STATE()) {
 
       case s_dead:
@@ -1791,14 +1811,47 @@ reexecute:
           goto error;
         }
 
-        UPDATE_STATE(s_headers_done);
-
         /* Set this here so that on_headers_complete() callbacks can see it */
         parser->upgrade =
           ((parser->flags & (F_UPGRADE | F_CONNECTION_UPGRADE)) ==
            (F_UPGRADE | F_CONNECTION_UPGRADE) ||
            parser->method == HTTP_CONNECT);
 
+        if (settings->on_headers_complete) {
+          /* Update the internal and externally-visible state. */
+          UPDATE_STATE(s_wait_for_on_headers_completed);
+          parser->waiting_for_headers_completed = 1;
+
+
+          /* If on_headers_complete is async, then we'll let the external code
+           * set the result in parser->headers_status, and advance the state to
+           * s_on_headers_completed by calling http_parser_on_headers_completed().
+           * If it is synchronous, then save the result and advance the state
+           * here.
+           */
+          if (settings->is_async_on_headers_complete) {
+            settings->on_headers_complete(parser);
+
+          } else {
+            parser->headers_status = settings->on_headers_complete(parser);
+            UPDATE_STATE(s_on_headers_completed);
+          }
+
+        } else {
+          UPDATE_STATE(s_headers_done);
+        }
+
+        REEXECUTE();
+      }
+
+      /* We enter this state in one of two ways: If on_headers_complete()
+       * is asynchronous, then external code sets the value of
+       * parser->headers_status, calls http_parser_on_headers_completed(),
+       * and then calls http_parser_exec() again. If it is synchronous, then
+       * we get here by just continuing to parse data.
+       */
+      case s_on_headers_completed:
+      {
         /* Here we call the headers_complete callback. This is somewhat
          * different than other callbacks because if the user returns 1, we
          * will interpret that as saying that this message has no body. This
@@ -1809,9 +1862,15 @@ reexecute:
          * we have to simulate it by handling a change in errno below.
          */
         if (settings->on_headers_complete) {
-          switch (settings->on_headers_complete(parser)) {
+          switch (parser->headers_status) {
             case 0:
               break;
+
+            /* This case indicates that the application has decided that, after
+             * processing the headers, it's done with the http parser.
+             */
+            case 3:
+              RETURN(p - data + 1);
 
             case 2:
               parser->upgrade = 1;
@@ -1829,6 +1888,8 @@ reexecute:
         if (HTTP_PARSER_ERRNO(parser) != HPE_OK) {
           RETURN(p - data);
         }
+
+        UPDATE_STATE(s_headers_done);
 
         REEXECUTE();
       }
@@ -2090,6 +2151,14 @@ error:
   RETURN(p - data);
 }
 
+void http_parser_on_headers_completed(http_parser *parser) {
+  /* We unfortunately have to set the state in two places. parser->state is
+   * used internally by the parser, and parser->waiting_for_headers_completed
+   * externally visible.
+   */
+  parser->state = s_on_headers_completed;
+  parser->waiting_for_headers_completed = 0;
+}
 
 /* Does the parser need to see an EOF to find the end of the message? */
 int
@@ -2150,12 +2219,18 @@ http_parser_init (http_parser *parser, enum http_parser_type t)
   parser->type = t;
   parser->state = (t == HTTP_REQUEST ? s_start_req : (t == HTTP_RESPONSE ? s_start_res : s_start_req_or_res));
   parser->http_errno = HPE_OK;
+
+  parser->is_running = 0;
+  parser->waiting_for_headers_completed = 0;
+  parser->headers_status = -1;
 }
 
 void
 http_parser_settings_init(http_parser_settings *settings)
 {
   memset(settings, 0, sizeof(*settings));
+  /* Default is to expect synchronous on_headers_complete. */
+  settings->is_async_on_headers_complete = 0;
 }
 
 const char *

--- a/src/http-parser/http_parser.h
+++ b/src/http-parser/http_parser.h
@@ -251,11 +251,6 @@ struct http_parser {
 
 
   /** ADDED FOR ASYNC on_headers_complete **/
-  /* If there's a on_headers_complete callback, 1 means the parser is
-   * waiting for it to indicate that it's finished by calling
-   * http_parser_on_headers_completed(), then call http_parser_execute()
-   * to continue parsing. */
-  int waiting_for_headers_completed;
   /* The status code set by the application code after processing the
    * headers. Initial value is -1. After headers have been processed, it should
    * be 0, 1, or 2. This is the value that would be returned by
@@ -347,8 +342,17 @@ size_t http_parser_execute(http_parser *parser,
                            const char *data,
                            size_t len);
 
-/* Tells the parser that the on_headers stuff is finished. */
-void http_parser_on_headers_completed(http_parser *parser);
+/* Return 1 if the parser is in the s_wait_for_on_headers_completed state,
+ * 0 otherwise. */
+int http_parser_waiting_for_headers_completed(http_parser *parser);
+
+/* This function is used when on_headers_complete() is an async function.
+ * Tells the parser that the on_headers stuff is finished. Need to pass it a
+ * status value, 0, 1, 2, or 3. This value is the same as what would be
+ * returned by the on_headers_complete() function when it is a synchronous
+ * function.
+ */
+void http_parser_headers_completed(http_parser *parser, int status);
 
 /* If http_should_keep_alive() in the on_headers_complete or
  * on_message_complete callback returns 0, then this should be

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>
+#include <later_api.h>
 
 #include <boost/bind.hpp>
 
@@ -22,6 +23,7 @@ http_parser_settings& request_settings() {
   settings.on_header_field = HttpRequest_on_header_field;
   settings.on_header_value = HttpRequest_on_header_value;
   settings.on_headers_complete = HttpRequest_on_headers_complete;
+  settings.is_async_on_headers_complete = 1;
   settings.on_body = HttpRequest_on_body;
   settings.on_message_complete = HttpRequest_on_message_complete;
   return settings;
@@ -41,6 +43,26 @@ void on_alloc(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf) {
 
 void HttpRequest::trace(const std::string& msg) {
   //std::cerr << msg << std::endl;
+}
+
+// Does a header field `name` exist?
+bool HttpRequest::_hasHeader(const std::string& name) const {
+  return _headers.find(name) != _headers.end();
+}
+
+// Does a header field `name` exist and have a particular value? If ci is
+// true, do a case-insensitive comparison of the value (fields are always
+// case- insensitive.)
+bool HttpRequest::_hasHeader(const std::string& name, const std::string& value, bool ci) const {
+  RequestHeaders::const_iterator item = _headers.find(name);
+  if (item == _headers.end())
+    return false;
+
+  if (ci) {
+    return strcasecmp(item->second.c_str(), value.c_str()) == 0;
+  } else {
+    return item->second == value;
+  }
 }
 
 uv_stream_t* HttpRequest::handle() {
@@ -211,47 +233,84 @@ int HttpRequest::_on_header_value(http_parser* pParser, const char* pAt, size_t 
   return 0;
 }
 
+// This should be called from the main thread.
+void HttpRequest::_call_r_on_headers() {
+  this->_pWebApplication->onHeaders(
+    this,
+    boost::bind(&HttpRequest::_on_headers_complete_complete, this, _1)
+  );
+}
+
+// This wrapper function is needed to use HttpRequest::_call_r_on_headers with
+// later(). That method can't be passed to later(), but this function can.
+void call_r_on_headers_wrapper(void* data) {
+  HttpRequest* req = (HttpRequest*) data;
+  req->_call_r_on_headers();
+}
+
+// This is called after http-parser has finished parsing the request headers.
+// It uses later() to schedule the user's R onHeaders() function. Always
+// returns 0. Normally 0 indicates success for http-parser, while 1 and 2
+// indicate errors or other conditions, but since we're processing the header
+// asynchronously, we don't know at this point if there has been an error. If
+// one of those conditions occurs, we'll set it later, but before we call
+// http_parser_execute() again.
 int HttpRequest::_on_headers_complete(http_parser* pParser) {
   trace("on_headers_complete");
 
+  later::later(call_r_on_headers_wrapper, this, 0);
+
+  return 0;
+}
+
+// This is called after the user's R onHeaders() function has finished. It can
+// write a response, if onHeaders() wants that. It also sets a status code for
+// http-parser.
+void HttpRequest::_on_headers_complete_complete(HttpResponse* pResponse) {
+  trace("on_headers_complete_complete");
   int result = 0;
 
-  HttpResponse* pResp = _pWebApplication->onHeaders(this);
-  if (pResp) {
-    bool bodyExpected = _headers.find("Content-Length") != _headers.end() ||
-      _headers.find("Transfer-Encoding") != _headers.end();
+  if (pResponse) {
+    bool bodyExpected = _hasHeader("Content-Length") || _hasHeader("Transfer-Encoding");
 
     if (bodyExpected) {
       // If we're expecting a request body and we're returning a response
       // prematurely, then add "Connection: close" header to the response and
       // set a flag to ignore all future reads on this connection.
 
-      pResp->addHeader("Connection", "close");
+      pResponse->addHeader("Connection", "close");
 
       uv_read_stop((uv_stream_t*)handle());
 
       _ignoreNewData = true;
     }
-    pResp->writeResponse();
+    pResponse->writeResponse();
 
     // result = 1 has special meaning to http_parser for this one callback; it
     // means F_SKIPBODY should be set on the parser. That's not what we want
-    // here; we just want processing to terminate.
-    result = 2;
+    // here; we just want processing to terminate, which we indicate with
+    // result = 3.
+    result = 3;
   }
   else {
     // If the request is Expect: Continue, and the app didn't say otherwise,
     // then give it what it wants
-    if (_headers.find("Expect") != _headers.end()
-        && _headers["Expect"] == "100-continue") {
-      pResp = new HttpResponse(this, 100, "Continue", NULL);
-      pResp->writeResponse();
+    if (_hasHeader("Expect", "100-continue")) {
+      pResponse = new HttpResponse(this, 100, "Continue", NULL);
+      pResponse->writeResponse();
     }
   }
 
-  // TODO: Allocate body
-  return result;
+  // Tell the parser what the result was.
+  this->_parser.headers_status = result;
+
+  // Tell the http parser it can move on.
+  http_parser_on_headers_completed(&(this->_parser));
+
+  // Continue parsing any data that went into the request buffer.
+  this->_parse_http_data_from_buffer();
 }
+
 
 int HttpRequest::_on_body(http_parser* pParser, const char* pAt, size_t length) {
   trace("on_body");
@@ -303,50 +362,74 @@ void HttpRequest::close() {
   uv_close(toHandle(&_handle.stream), HttpRequest_on_closed);
 }
 
+void HttpRequest::_parse_http_data(char* buffer, const ssize_t n) {
+  int parsed = http_parser_execute(&_parser, &request_settings(), buffer, n);
+
+  if (_parser.waiting_for_headers_completed) {
+    // If we're waiting for the header response, just store the data in the
+    // buffer.
+    _requestBuffer.append(buffer + parsed, n - parsed);
+
+  } else if (_parser.upgrade) {
+    char* pData = buffer + parsed;
+    size_t pDataLen = n - parsed;
+
+    if (_pWebSocketConnection->accept(_headers, pData, pDataLen)) {
+      // Freed in on_response_written
+      InMemoryDataSource* pDS = new InMemoryDataSource();
+      HttpResponse* pResp = new HttpResponse(this, 101, "Switching Protocols",
+        pDS);
+
+      std::vector<uint8_t> body;
+      _pWebSocketConnection->handshake(_url, _headers, &pData, &pDataLen,
+                                       &pResp->headers(), &body);
+      if (body.size() > 0) {
+        pDS->add(body);
+      }
+      body.empty();
+
+      pResp->writeResponse();
+
+      _protocol = WebSockets;
+      _pWebApplication->onWSOpen(this);
+
+      _pWebSocketConnection->read(pData, pDataLen);
+    }
+
+    if (_protocol != WebSockets) {
+      // TODO: Write failure
+      close();
+    }
+  } else if (parsed < n) {
+    if (!_ignoreNewData) {
+      fatal_error(
+        "on_request_read",
+        http_errno_description(HTTP_PARSER_ERRNO(&_parser))
+      );
+      uv_read_stop((uv_stream_t*)handle());
+      close();
+    }
+  }
+}
+
+void HttpRequest::_parse_http_data_from_buffer() {
+  // First create a non-const char* from _requestBuffer.
+  std::vector<char> req_buffer(_requestBuffer.begin(), _requestBuffer.end());
+
+  // Clear the _requestBuffer. It might be written to in _parse_http_data().
+  _requestBuffer.clear();
+
+  this->_parse_http_data(&req_buffer[0], req_buffer.size());
+}
+
 void HttpRequest::_on_request_read(uv_stream_t*, ssize_t nread, const uv_buf_t* buf) {
   if (nread > 0) {
     //std::cerr << nread << " bytes read\n";
     if (_ignoreNewData) {
       // Do nothing
     } else if (_protocol == HTTP) {
-      int parsed = http_parser_execute(&_parser, &request_settings(), buf->base, nread);
-      if (_parser.upgrade) {
-        char* pData = buf->base + parsed;
-        size_t pDataLen = nread - parsed;
+      this->_parse_http_data(buf->base, nread);
 
-        if (_pWebSocketConnection->accept(_headers, pData, pDataLen)) {
-          // Freed in on_response_written
-          InMemoryDataSource* pDS = new InMemoryDataSource();
-          HttpResponse* pResp = new HttpResponse(this, 101, "Switching Protocols",
-            pDS);
-
-          std::vector<uint8_t> body;
-          _pWebSocketConnection->handshake(_url, _headers, &pData, &pDataLen,
-                                           &pResp->headers(), &body);
-          if (body.size() > 0) {
-            pDS->add(body);
-          }
-          body.empty();
-
-          pResp->writeResponse();
-
-          _protocol = WebSockets;
-          _pWebApplication->onWSOpen(this);
-
-          _pWebSocketConnection->read(pData, pDataLen);
-        }
-
-        if (_protocol != WebSockets) {
-          // TODO: Write failure
-          close();
-        }
-      } else if (parsed < nread) {
-        if (!_ignoreNewData) {
-          fatal_error("on_request_read", "parse error");
-          uv_read_stop((uv_stream_t*)handle());
-          close();
-        }
-      }
     } else if (_protocol == WebSockets) {
       _pWebSocketConnection->read(buf->base, nread);
     }

--- a/src/http.h
+++ b/src/http.h
@@ -23,9 +23,7 @@ enum Protocol {
 class WebApplication {
 public:
   virtual ~WebApplication() {}
-  virtual HttpResponse* onHeaders(HttpRequest* pRequest) {
-    return NULL;
-  }
+  virtual void onHeaders(HttpRequest* pRequest, boost::function<void(HttpResponse*)> callback) = 0;
   virtual void onBodyData(HttpRequest* pRequest,
                           const char* data, size_t len) = 0;
   virtual void getResponse(HttpRequest* request, boost::function<void(HttpResponse*)> callback) = 0;
@@ -93,6 +91,17 @@ private:
 
   void trace(const std::string& msg);
 
+  bool _hasHeader(const std::string& name) const;
+  bool _hasHeader(const std::string& name, const std::string& value, bool ci = false) const;
+
+  void _parse_http_data(char* buf, const ssize_t n);
+  // Parse data that has been stored in the buffer.
+  void _parse_http_data_from_buffer();
+
+  // For buffering the incoming HTTP request when data comes in while waiting
+  // for R to process headers.
+  std::string _requestBuffer;
+
 public:
   HttpRequest(uv_loop_t* pLoop, WebApplication* pWebApplication,
       Socket* pSocket)
@@ -144,6 +153,8 @@ public:
   virtual int _on_header_field(http_parser* pParser, const char* pAt, size_t length);
   virtual int _on_header_value(http_parser* pParser, const char* pAt, size_t length);
   virtual int _on_headers_complete(http_parser* pParser);
+  virtual void _call_r_on_headers();
+  virtual void _on_headers_complete_complete(HttpResponse* pResponse);
   virtual int _on_body(http_parser* pParser, const char* pAt, size_t length);
   virtual int _on_message_complete(http_parser* pParser);
   virtual void _on_message_complete_complete(HttpResponse* pResponse);

--- a/src/http.h
+++ b/src/http.h
@@ -100,7 +100,7 @@ private:
 
   // For buffering the incoming HTTP request when data comes in while waiting
   // for R to process headers.
-  std::string _requestBuffer;
+  std::vector<char> _requestBuffer;
 
 public:
   HttpRequest(uv_loop_t* pLoop, WebApplication* pWebApplication,

--- a/src/httpuv.cpp
+++ b/src/httpuv.cpp
@@ -255,16 +255,17 @@ public:
   virtual ~RWebApplication() {
   }
 
-  virtual HttpResponse* onHeaders(HttpRequest* pRequest) {
+  virtual void onHeaders(HttpRequest* pRequest, boost::function<void(HttpResponse*)> callback) {
     if (_onHeaders.isNULL()) {
-      return NULL;
+      callback(NULL);
     }
 
     requestToEnv(pRequest, &pRequest->env());
 
+    // Call the R onHeaders function
     Rcpp::List response(_onHeaders(pRequest->env()));
 
-    return listToResponse(pRequest, response);
+    callback(listToResponse(pRequest, response));
   }
 
   virtual void onBodyData(HttpRequest* pRequest,


### PR DESCRIPTION
This pull request uses `later()` to call the user's `onHeaders()` function asynchronously. This is a necessary step for running the I/O on a background thread, but I thought it deserved its own PR and code review.

This also fixes #96.