### PR TITLE
Use correct keep-alive behavior

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ httpuv 1.3.5.9002
 
 * httpuv can now handle request callbacks asynchronously. ([#80](https://github.com/rstudio/httpuv/pull/80))
 
+* Fixed [#72](https://github.com/rstudio/httpuv/issues/72): httpuv previously did not close connections that had the `Connection: close` header, or were HTTP 1.0 (without `Connection: keep-alive`). ([#99](https://github.com/rstudio/httpuv/pull/99))
+
 * Let Rcpp handle symbol registration. ([#85](https://github.com/rstudio/httpuv/pull/85))
 
 * Hide internal symbols from shared library on supported platforms. This reduces the risk of conflicts with other packages bundling libuv. ([#85](https://github.com/rstudio/httpuv/pull/85))

--- a/src/http.h
+++ b/src/http.h
@@ -178,6 +178,7 @@ class HttpResponse {
   ResponseHeaders _headers;
   std::vector<char> _responseHeader;
   DataSource* _pBody;
+  bool _closeAfterWritten;
 
 public:
   HttpResponse(HttpRequest* pRequest, int statusCode,
@@ -192,8 +193,11 @@ public:
   ResponseHeaders& headers();
 
   void addHeader(const std::string& name, const std::string& value);
+  void setHeader(const std::string& name, const std::string& value);
   void writeResponse();
   void onResponseWritten(int status);
+  void closeAfterWritten();
+  void destroy(bool forceClose = false);
 };
 
 #define DECLARE_CALLBACK_1(type, function_name, return_type, type_1) \


### PR DESCRIPTION
This fixes #98. Now when either of:

* HTTP 1.0 request with no `Connection` header
* HTTP 1.1 request with a `Connection: close` header

comes in, httpuv will add a `Connection: close` **response** header and stop paying attention to incoming data.