### PR TITLE
Fix some compile issues with gcc 4.4.7

### DIFF
--- a/src/http.h
+++ b/src/http.h
@@ -46,6 +46,13 @@ void freeServer(uv_stream_t* pServer);
 bool runNonBlocking(uv_loop_t* loop);
 
 
+// NOTE: externalize/internalize_shared_ptr were originally template functions
+// but were made into non-template functions because gcc 4.4.7 (used on RHEL
+// 6) gives the following error with the templated versions:
+//   sorry, unimplemented: mangling template_id_expr
+// This was due to a bug in gcc which was fixed in later versions.
+//   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=38600
+
 // externalize_shared_ptr is used to pass a shared_ptr to R, and have its
 // lifetime be tied to the R external pointer object. This function creates a
 // copy of the shared_ptr (incrementing the shared_ptr's target's refcount)
@@ -60,17 +67,16 @@ bool runNonBlocking(uv_loop_t* loop);
 //
 // The reason we need the explicit Xptr type is because we want to set the last
 // argument (finalizeOnExit) to true.
-template <typename T>
-Rcpp::XPtr<boost::shared_ptr<T>,
+inline Rcpp::XPtr<boost::shared_ptr<WebSocketConnection>,
           Rcpp::PreserveStorage,
-          Rcpp::standard_delete_finalizer<boost::shared_ptr<T>>,
-          true> externalize_shared_ptr(boost::shared_ptr<T> obj)
+          Rcpp::standard_delete_finalizer<boost::shared_ptr<WebSocketConnection>>,
+          true> externalize_shared_ptr(boost::shared_ptr<WebSocketConnection> obj)
 {
-  boost::shared_ptr<T>* obj_copy = new boost::shared_ptr<T>(obj);
+  boost::shared_ptr<WebSocketConnection>* obj_copy = new boost::shared_ptr<WebSocketConnection>(obj);
 
-  Rcpp::XPtr<boost::shared_ptr<T>,
+  Rcpp::XPtr<boost::shared_ptr<WebSocketConnection>,
              Rcpp::PreserveStorage,
-             Rcpp::standard_delete_finalizer<boost::shared_ptr<T>>,
+             Rcpp::standard_delete_finalizer<boost::shared_ptr<WebSocketConnection>>,
              true>
             obj_xptr(obj_copy, true);
 
@@ -79,14 +85,13 @@ Rcpp::XPtr<boost::shared_ptr<T>,
 
 // Given an XPtr to a shared_ptr, return a copy of the shared_ptr. This
 // increases the shared_ptr's ref count by one.
-template <typename T>
-boost::shared_ptr<T> internalize_shared_ptr(
-  Rcpp::XPtr<boost::shared_ptr<T>,
+inline boost::shared_ptr<WebSocketConnection> internalize_shared_ptr(
+  Rcpp::XPtr<boost::shared_ptr<WebSocketConnection>,
              Rcpp::PreserveStorage,
-             Rcpp::standard_delete_finalizer<boost::shared_ptr<T>>,
+             Rcpp::standard_delete_finalizer<boost::shared_ptr<WebSocketConnection>>,
              true> obj_xptr)
 {
-  boost::shared_ptr<T>* obj_copy = obj_xptr.get();
+  boost::shared_ptr<WebSocketConnection>* obj_copy = obj_xptr.get();
   // Return a copy of the shared pointer.
   return *obj_copy;
 }

--- a/src/httprequest.h
+++ b/src/httprequest.h
@@ -90,7 +90,6 @@ public:
       _pWebApplication(pWebApplication),
       _pSocket(pSocket),
       _protocol(HTTP),
-      _env(NULL),
       _ignoreNewData(false),
       _is_closing(false),
       _response_scheduled(false),

--- a/src/utils.h
+++ b/src/utils.h
@@ -49,7 +49,10 @@ inline void err_printf(const char *fmt, ...) {
   if (n == -1)
     return;
 
-  write(STDERR_FILENO, buf, n);
+  ssize_t res = write(STDERR_FILENO, buf, n);
+  // This is here simply to avoid a warning about "ignoring return value" of
+  // the write(), on some compilers. (Seen with gcc 4.4.7 on RHEL 6)
+  res = 0;
 }
 
 

--- a/src/webapplication.cpp
+++ b/src/webapplication.cpp
@@ -313,7 +313,7 @@ void RWebApplication::onWSOpen(boost::shared_ptr<HttpRequest> pRequest,
   requestToEnv(pRequest, &pRequest->env());
   try {
     _onWSOpen(
-      externalize_shared_ptr<WebSocketConnection>(pRequest->websocket()),
+      externalize_shared_ptr(pRequest->websocket()),
       pRequest->env()
     );
   } catch(...) {
@@ -331,13 +331,13 @@ void RWebApplication::onWSMessage(boost::shared_ptr<WebSocketConnection> pConn,
   try {
     if (binary)
       _onWSMessage(
-        externalize_shared_ptr<WebSocketConnection>(pConn),
+        externalize_shared_ptr(pConn),
         binary,
         std::vector<uint8_t>(data, data + len)
       );
     else
       _onWSMessage(
-        externalize_shared_ptr<WebSocketConnection>(pConn),
+        externalize_shared_ptr(pConn),
         binary,
         std::string(data, len)
       );
@@ -348,5 +348,5 @@ void RWebApplication::onWSMessage(boost::shared_ptr<WebSocketConnection> pConn,
 
 void RWebApplication::onWSClose(boost::shared_ptr<WebSocketConnection> pConn) {
   ASSERT_MAIN_THREAD()
-  _onWSClose(externalize_shared_ptr<WebSocketConnection>(pConn));
+  _onWSClose(externalize_shared_ptr(pConn));
 }

--- a/src/webapplication.cpp
+++ b/src/webapplication.cpp
@@ -143,8 +143,10 @@ boost::shared_ptr<HttpResponse> listToResponse(
   ASSERT_MAIN_THREAD()
   using namespace Rcpp;
 
-  if (response.isNULL() || response.size() == 0)
-    return NULL;
+  if (response.isNULL() || response.size() == 0) {
+    boost::shared_ptr<HttpResponse> null_ptr;
+    return null_ptr;
+  }
 
   CharacterVector names = response.names();
 
@@ -205,7 +207,8 @@ void RWebApplication::onHeaders(boost::shared_ptr<HttpRequest> pRequest,
 {
   ASSERT_MAIN_THREAD()
   if (_onHeaders.isNULL()) {
-    callback(NULL);
+    boost::shared_ptr<HttpResponse> null_ptr;
+    callback(null_ptr);
   }
 
   requestToEnv(pRequest, &pRequest->env());


### PR DESCRIPTION
This fixes some compiler errors with gcc 4.4.7 on RHEL 6. It is related to #110, but the original issue there appears to be a different problem.
