### PR TITLE
Avoid NULL WebSocketConnection

### DIFF
--- a/src/http.cpp
+++ b/src/http.cpp
@@ -12,7 +12,6 @@
 #include <iostream>
 #include <sstream>
 #include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
 
 
 // TODO: Streaming response body (with chunked transfer encoding)

--- a/src/http.h
+++ b/src/http.h
@@ -8,6 +8,7 @@
 #include "websockets.h"
 #include "callbackqueue.h"
 #include "utils.h"
+#include "auto_deleter.h"
 
 typedef struct {
   union {
@@ -68,17 +69,17 @@ bool runNonBlocking(uv_loop_t* loop);
 // The reason we need the explicit Xptr type is because we want to set the last
 // argument (finalizeOnExit) to true.
 inline Rcpp::XPtr<boost::shared_ptr<WebSocketConnection>,
-          Rcpp::PreserveStorage,
-          Rcpp::standard_delete_finalizer<boost::shared_ptr<WebSocketConnection>>,
-          true> externalize_shared_ptr(boost::shared_ptr<WebSocketConnection> obj)
+                  Rcpp::PreserveStorage,
+                  auto_deleter_background<boost::shared_ptr<WebSocketConnection>>,
+                  true> externalize_shared_ptr(boost::shared_ptr<WebSocketConnection> obj)
 {
+  ASSERT_MAIN_THREAD()
   boost::shared_ptr<WebSocketConnection>* obj_copy = new boost::shared_ptr<WebSocketConnection>(obj);
 
   Rcpp::XPtr<boost::shared_ptr<WebSocketConnection>,
              Rcpp::PreserveStorage,
-             Rcpp::standard_delete_finalizer<boost::shared_ptr<WebSocketConnection>>,
-             true>
-            obj_xptr(obj_copy, true);
+             auto_deleter_background<boost::shared_ptr<WebSocketConnection>>,
+             true> obj_xptr(obj_copy, true);
 
   return obj_xptr;
 }
@@ -88,9 +89,10 @@ inline Rcpp::XPtr<boost::shared_ptr<WebSocketConnection>,
 inline boost::shared_ptr<WebSocketConnection> internalize_shared_ptr(
   Rcpp::XPtr<boost::shared_ptr<WebSocketConnection>,
              Rcpp::PreserveStorage,
-             Rcpp::standard_delete_finalizer<boost::shared_ptr<WebSocketConnection>>,
+             auto_deleter_background<boost::shared_ptr<WebSocketConnection>>,
              true> obj_xptr)
 {
+  ASSERT_MAIN_THREAD()
   boost::shared_ptr<WebSocketConnection>* obj_copy = obj_xptr.get();
   // Return a copy of the shared pointer.
   return *obj_copy;

--- a/src/httprequest.cpp
+++ b/src/httprequest.cpp
@@ -583,6 +583,11 @@ void HttpRequest::closeWSSocket() {
 void HttpRequest::_on_closed(uv_handle_t* handle) {
   ASSERT_BACKGROUND_THREAD()
   trace("HttpRequest::_on_closed");
+  // Tell the WebSocketConnection that the connection is closed, before
+  // resetting the shared_ptr. This is useful because there may be some
+  // callbacks that will execute later, and we want to make sure the WSC
+  // doesn't try to do anything with them.
+  _pWebSocketConnection->markClosed();
   _pWebSocketConnection.reset();
 }
 

--- a/src/httprequest.cpp
+++ b/src/httprequest.cpp
@@ -771,7 +771,7 @@ void HttpRequest::_on_request_read(uv_stream_t*, ssize_t nread, const uv_buf_t* 
       _pWebSocketConnection->read(buf->base, nread);
     }
   } else if (nread < 0) {
-    if (nread == UV_EOF /*|| err.code == UV_ECONNRESET*/) {
+    if (nread == UV_EOF || nread == UV_ECONNRESET) {
     } else {
       fatal_error("on_request_read", uv_strerror(nread));
     }

--- a/src/httprequest.cpp
+++ b/src/httprequest.cpp
@@ -643,6 +643,12 @@ void HttpRequest::_call_r_on_ws_open() {
   ASSERT_MAIN_THREAD()
   trace("_call_r_on_ws_open");
 
+  boost::function<void (void)> error_callback(
+    boost::bind(&HttpRequest::schedule_close, shared_from_this())
+  );
+
+  this->_pWebApplication->onWSOpen(shared_from_this(), error_callback);
+
   boost::shared_ptr<WebSocketConnection> p_wsc = _pWebSocketConnection;
   // It's possible for _pWebSocketConnection to have had its refcount drop to
   // zero from another thread or earlier callback in this thread. If that
@@ -650,11 +656,6 @@ void HttpRequest::_call_r_on_ws_open() {
   if (!p_wsc) {
     return;
   }
-
-  boost::function<void (void)> error_callback(
-    boost::bind(&HttpRequest::schedule_close, shared_from_this())
-  );
-  this->_pWebApplication->onWSOpen(shared_from_this(), error_callback);
 
   // _requestBuffer is likely empty at this point, but copy its contents and
   // _pass along just in case.

--- a/src/httpuv.cpp
+++ b/src/httpuv.cpp
@@ -150,7 +150,10 @@ void sendWSMessage(SEXP conn,
                    Rcpp::RObject message)
 {
   ASSERT_MAIN_THREAD()
-  Rcpp::XPtr<boost::shared_ptr<WebSocketConnection>, Rcpp::PreserveStorage, Rcpp::standard_delete_finalizer<boost::shared_ptr<WebSocketConnection>>, true> conn_xptr(conn);
+  Rcpp::XPtr<boost::shared_ptr<WebSocketConnection>,
+             Rcpp::PreserveStorage,
+             auto_deleter_background<boost::shared_ptr<WebSocketConnection>>,
+             true> conn_xptr(conn);
   boost::shared_ptr<WebSocketConnection> wsc = internalize_shared_ptr(conn_xptr);
 
   Opcode mode;
@@ -194,7 +197,10 @@ void closeWS(SEXP conn,
 {
   ASSERT_MAIN_THREAD()
   trace("closeWS\n");
-  Rcpp::XPtr<boost::shared_ptr<WebSocketConnection>, Rcpp::PreserveStorage, Rcpp::standard_delete_finalizer<boost::shared_ptr<WebSocketConnection>>, true> conn_xptr(conn);
+  Rcpp::XPtr<boost::shared_ptr<WebSocketConnection>,
+             Rcpp::PreserveStorage,
+             auto_deleter_background<boost::shared_ptr<WebSocketConnection>>,
+             true> conn_xptr(conn);
   boost::shared_ptr<WebSocketConnection> wsc = internalize_shared_ptr(conn_xptr);
 
   // Schedule on background thread:

--- a/src/webapplication.cpp
+++ b/src/webapplication.cpp
@@ -234,7 +234,7 @@ void RWebApplication::onHeaders(boost::shared_ptr<HttpRequest> pRequest,
 }
 
 void RWebApplication::onBodyData(boost::shared_ptr<HttpRequest> pRequest,
-      const char* pData, size_t length,
+      boost::shared_ptr<std::vector<char>> data,
       boost::function<void(boost::shared_ptr<HttpResponse>)> errorCallback)
 {
   ASSERT_MAIN_THREAD()
@@ -245,8 +245,8 @@ void RWebApplication::onBodyData(boost::shared_ptr<HttpRequest> pRequest,
   if (pRequest->isResponseScheduled())
     return;
 
-  Rcpp::RawVector rawVector(length);
-  std::copy(pData, pData + length, rawVector.begin());
+  Rcpp::RawVector rawVector(data->size());
+  std::copy(data->begin(), data->end(), rawVector.begin());
   try {
     _onBodyData(pRequest->env(), rawVector);
   } catch (...) {
@@ -323,8 +323,7 @@ void RWebApplication::onWSOpen(boost::shared_ptr<HttpRequest> pRequest,
 
 void RWebApplication::onWSMessage(boost::shared_ptr<WebSocketConnection> pConn,
                                   bool binary,
-                                  const char* data,
-                                  size_t len,
+                                  boost::shared_ptr<std::vector<char>> data,
                                   boost::function<void(void)> error_callback)
 {
   ASSERT_MAIN_THREAD()
@@ -333,13 +332,13 @@ void RWebApplication::onWSMessage(boost::shared_ptr<WebSocketConnection> pConn,
       _onWSMessage(
         externalize_shared_ptr(pConn),
         binary,
-        std::vector<uint8_t>(data, data + len)
+        std::vector<uint8_t>(data->begin(), data->end())
       );
     else
       _onWSMessage(
         externalize_shared_ptr(pConn),
         binary,
-        std::string(data, len)
+        std::string(data->begin(), data->end())
       );
   } catch(...) {
     error_callback();

--- a/src/webapplication.cpp
+++ b/src/webapplication.cpp
@@ -310,10 +310,15 @@ void RWebApplication::getResponse(boost::shared_ptr<HttpRequest> pRequest,
 void RWebApplication::onWSOpen(boost::shared_ptr<HttpRequest> pRequest,
                                boost::function<void(void)> error_callback) {
   ASSERT_MAIN_THREAD()
+  boost::shared_ptr<WebSocketConnection> pConn = pRequest->websocket();
+  if (!pConn) {
+    return;
+  }
+
   requestToEnv(pRequest, &pRequest->env());
   try {
     _onWSOpen(
-      externalize_shared_ptr(pRequest->websocket()),
+      externalize_shared_ptr(pConn),
       pRequest->env()
     );
   } catch(...) {

--- a/src/webapplication.h
+++ b/src/webapplication.h
@@ -16,7 +16,7 @@ public:
   virtual void onHeaders(boost::shared_ptr<HttpRequest> pRequest,
                          boost::function<void(boost::shared_ptr<HttpResponse>)> callback) = 0;
   virtual void onBodyData(boost::shared_ptr<HttpRequest> pRequest,
-                          const char* data, size_t len,
+                          boost::shared_ptr<std::vector<char>> data,
                           boost::function<void(boost::shared_ptr<HttpResponse>)> errorCallback) = 0;
   virtual void getResponse(boost::shared_ptr<HttpRequest> request,
                            boost::function<void(boost::shared_ptr<HttpResponse>)> callback) = 0;
@@ -24,8 +24,7 @@ public:
                         boost::function<void(void)> error_callback) = 0;
   virtual void onWSMessage(boost::shared_ptr<WebSocketConnection>,
                            bool binary,
-                           const char* data,
-                           size_t len,
+                           boost::shared_ptr<std::vector<char>> data,
                            boost::function<void(void)> error_callback) = 0;
   virtual void onWSClose(boost::shared_ptr<WebSocketConnection>) = 0;
 };
@@ -59,7 +58,7 @@ public:
   virtual void onHeaders(boost::shared_ptr<HttpRequest> pRequest,
                          boost::function<void(boost::shared_ptr<HttpResponse>)> callback);
   virtual void onBodyData(boost::shared_ptr<HttpRequest> pRequest,
-                          const char* data, size_t len,
+                          boost::shared_ptr<std::vector<char>> data,
                           boost::function<void(boost::shared_ptr<HttpResponse>)> errorCallback);
   virtual void getResponse(boost::shared_ptr<HttpRequest> request,
                            boost::function<void(boost::shared_ptr<HttpResponse>)> callback);
@@ -67,8 +66,7 @@ public:
                         boost::function<void(void)> error_callback);
   virtual void onWSMessage(boost::shared_ptr<WebSocketConnection> conn,
                            bool binary,
-                           const char* data,
-                           size_t len,
+                           boost::shared_ptr<std::vector<char>> data,
                            boost::function<void(void)> error_callback);
   virtual void onWSClose(boost::shared_ptr<WebSocketConnection> conn);
 };

--- a/src/websockets.cpp
+++ b/src/websockets.cpp
@@ -364,7 +364,6 @@ void WebSocketConnection::onFrameComplete() {
         break;
       }
       case Close: {
-  trace("WebSocketConnection::onFrameComplete Close");
 
         if (_connState == WS_OPEN) {
           _connState = WS_CLOSE_RECEIVED;
@@ -384,9 +383,6 @@ void WebSocketConnection::onFrameComplete() {
 
         // TODO: Use code and status
         _pCallbacks->onWSClose(0);
-
-        // TODO: Is this necessary?
-        // _pCallbacks.reset();
 
         break;
       }

--- a/src/websockets.cpp
+++ b/src/websockets.cpp
@@ -295,6 +295,11 @@ void WebSocketConnection::read(const char* data, size_t len) {
   _pParser->read(data, len);
 }
 
+void WebSocketConnection::read(boost::shared_ptr<std::vector<char>> buf) {
+  ASSERT_BACKGROUND_THREAD()
+  read(&(*buf)[0], buf->size());
+}
+
 void WebSocketConnection::onHeaderComplete(const WSFrameHeaderInfo& header) {
   ASSERT_BACKGROUND_THREAD()
   _header = header;

--- a/src/websockets.h
+++ b/src/websockets.h
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <vector>
+#include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
 
 #include "utils.h"
@@ -186,6 +187,7 @@ public:
   void sendWSMessage(Opcode opcode, const char* pData, size_t length);
   void closeWS(uint16_t code = 1000, std::string reason = "");
   void read(const char* data, size_t len);
+  void read(boost::shared_ptr<std::vector<char>> buf);
 
 protected:
   void onHeaderComplete(const WSFrameHeaderInfo& header);

--- a/src/websockets.h
+++ b/src/websockets.h
@@ -137,11 +137,17 @@ public:
   void read(const char* data, size_t len);
 };
 
-typedef uint8_t WSConnState;
-const WSConnState WS_OPEN = 0;
-const WSConnState WS_CLOSE_RECEIVED = 1;
-const WSConnState WS_CLOSE_SENT = 2;
-const WSConnState WS_CLOSE = WS_CLOSE_RECEIVED | WS_CLOSE_SENT;
+
+enum WSConnState {
+  WS_OPEN,
+  WS_CLOSE_RECEIVED,
+  WS_CLOSE_SENT,
+  // This can represent two cases:
+  //   1. When a close message is received, and a close message is sent.
+  //   2. When the connection was simply closed without any messages.
+  // It may be useful in the future to split this up.
+  WS_CLOSED
+};
 
 class WebSocketConnectionCallbacks {
 public:

--- a/src/websockets.h
+++ b/src/websockets.h
@@ -194,6 +194,7 @@ public:
   void closeWS(uint16_t code = 1000, std::string reason = "");
   void read(const char* data, size_t len);
   void read(boost::shared_ptr<std::vector<char>> buf);
+  void markClosed();
 
 protected:
   void onHeaderComplete(const WSFrameHeaderInfo& header);


### PR DESCRIPTION
This fixes #112. It checks that `_pWebSocketConnection` is not null before scheduling operations with it. It also ensures that the `WebSocketConnection` objects are deleted on the background thread.

There is also now a `WebSocketConnection::markClosed()` method. This can be called to indicate that the connection has been closed without going through the normal sending and receiving of a close message.

There's one more change that's tangential: it converts `vector<char>*` to `shared_ptr`s, which means that the deletion doesn't have to be manually scheduled.
