### PR TITLE
Make sure to use local copies of library headers

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -20,7 +20,7 @@ ifeq ($(UNAME), OpenBSD)
 PKG_LIBS += -lkvm
 endif
 
-PKG_CPPFLAGS = -I./libuv/include -I./http-parser -I./sha1 -I./base64 $(C_VISIBILITY)
+PKG_CPPFLAGS = $(C_VISIBILITY)
 
 # To avoid spurious warnings from `R CMD check --as-cran`, about compiler
 # warning flags like -Werror.

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -4,7 +4,7 @@ CXX_STD=CXX11
 PKG_LIBS = ./libuv/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o \
 	-lpthread -lws2_32 -lkernel32 -lpsapi -liphlpapi -lshell32 -luserenv
 
-PKG_CPPFLAGS += -I./libuv/include -I./http-parser -I./sha1 -I./base64 -D_WIN32_WINNT=0x0600 -DSTRICT_R_HEADERS
+PKG_CPPFLAGS += -D_WIN32_WINNT=0x0600 -DSTRICT_R_HEADERS
 CFLAGS += -D_WIN32_WINNT=0x0600 -DSTRICT_R_HEADERS
 
 # Additional flags for libuv borrowed from libuv/Makefile.mingw

--- a/src/callbackqueue.cpp
+++ b/src/callbackqueue.cpp
@@ -2,7 +2,7 @@
 #include "queue.h"
 #include "thread.h"
 #include <boost/function.hpp>
-#include <uv.h>
+#include "libuv/include/uv.h"
 
 
 // This non-class function is a plain C wrapper for CallbackQueue::flush(), and

--- a/src/callbackqueue.h
+++ b/src/callbackqueue.h
@@ -3,7 +3,7 @@
 
 #include "queue.h"
 #include <boost/function.hpp>
-#include <uv.h>
+#include "libuv/include/uv.h"
 
 class CallbackQueue {
 public:

--- a/src/http.h
+++ b/src/http.h
@@ -1,7 +1,7 @@
 #ifndef HTTP_HPP
 #define HTTP_HPP
 
-#include <uv.h>
+#include "libuv/include/uv.h"
 #include <boost/shared_ptr.hpp>
 #include <boost/bind.hpp>
 #include "webapplication.h"

--- a/src/httprequest.h
+++ b/src/httprequest.h
@@ -8,8 +8,8 @@
 #include <boost/bind.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/shared_ptr.hpp>
-#include <uv.h>
-#include <http_parser.h>
+#include "libuv/include/uv.h"
+#include "http-parser/http_parser.h"
 #include "socket.h"
 #include "webapplication.h"
 #include "callbackqueue.h"

--- a/src/httpresponse.cpp
+++ b/src/httpresponse.cpp
@@ -3,7 +3,7 @@
 #include "constants.h"
 #include "thread.h"
 #include "utils.h"
-#include <uv.h>
+#include "libuv/include/uv.h"
 
 
 void on_response_written(uv_write_t* handle, int status) {

--- a/src/httpuv.cpp
+++ b/src/httpuv.cpp
@@ -7,8 +7,8 @@
 #include <errno.h>
 #include <boost/function.hpp>
 #include <boost/bind.hpp>
-#include <uv.h>
-#include <base64.hpp>
+#include "libuv/include/uv.h"
+#include "base64/base64.hpp"
 #include "uvutil.h"
 #include "webapplication.h"
 #include "http.h"

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -1,7 +1,7 @@
 #include "socket.h"
 #include "httprequest.h"
 #include <later_api.h>
-#include <uv.h>
+#include "libuv/include/uv.h"
 
 void on_Socket_close(uv_handle_t* pHandle);
 

--- a/src/socket.h
+++ b/src/socket.h
@@ -3,7 +3,7 @@
 
 #include "http.h"
 #include <boost/shared_ptr.hpp>
-#include <uv.h>
+#include "libuv/include/uv.h"
 
 class HttpRequest;
 class WebApplication;

--- a/src/thread.h
+++ b/src/thread.h
@@ -1,7 +1,7 @@
 #ifndef THREAD_HPP
 #define THREAD_HPP
 
-#include <uv.h>
+#include "libuv/include/uv.h"
 
 // These must be called from the main and background thread, respectively, so
 // that is_main_thread() and is_background_thread() can be tested later.

--- a/src/uvutil.h
+++ b/src/uvutil.h
@@ -4,7 +4,7 @@
 #include "thread.h"
 #include <string>
 #include <vector>
-#include <uv.h>
+#include "libuv/include/uv.h"
 
 /* Prevent naming conflicts for Free() and Calloc() */
 #define R_NO_REMAP

--- a/src/webapplication.h
+++ b/src/webapplication.h
@@ -2,7 +2,7 @@
 #define WEBAPPLICATION_HPP
 
 #include <boost/function.hpp>
-#include <uv.h>
+#include "libuv/include/uv.h"
 #include <Rcpp.h>
 #include "websockets.h"
 #include "thread.h"

--- a/src/websockets-ietf.cpp
+++ b/src/websockets-ietf.cpp
@@ -1,7 +1,7 @@
 #include "websockets-ietf.h"
 
-#include <sha1.h>
-#include <base64.hpp>
+#include "sha1/sha1.h"
+#include "base64/base64.hpp"
 
 bool WebSocketProto_IETF::canHandle(const RequestHeaders& requestHeaders,
                                     const char* pData, size_t len) const {

--- a/src/websockets.cpp
+++ b/src/websockets.cpp
@@ -8,8 +8,8 @@
 #include <iomanip>
 #include <memory>
 
-#include <sha1.h>
-#include <base64.hpp>
+#include "sha1/sha1.h"
+#include "base64/base64.hpp"
 
 #include "websockets-ietf.h"
 #include "websockets-hybi03.h"


### PR DESCRIPTION
This ensures that the local version of library headers will be used. I believe this will fix #71 and a number of other issues related to build errors.