### PR TITLE
Don't to call _on_closed callbacks twice

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ httpuv 1.4.1.9000
 
 * Fixed [#126](https://github.com/rstudio/httpuv/issues/126): The Makevars.win file had a line with spaces instead of a tab. This caused problems when installing with the `--clean` flag.
 
+* Fixed [#128](https://github.com/rstudio/httpuv/issues/128): It was possible in rare cases for a segfault to occur when httpuv tried to close a connection twice. ([#129](https://github.com/rstudio/httpuv/pulls/129))
+
 httpuv 1.4.1
 ============
 

--- a/src/auto_deleter.h
+++ b/src/auto_deleter.h
@@ -27,7 +27,7 @@ void auto_deleter_main(void* obj) {
     later::later(auto_deleter_main<T>, obj, 0);
 
   } else {
-    throw std::runtime_error("Can't detect correct thread for auto_deleter_main.");
+    trace("Can't detect correct thread for auto_deleter_main.");
   }
 }
 
@@ -46,7 +46,7 @@ void auto_deleter_background(T* obj) {
     } catch (...) {}
 
   } else {
-    throw std::runtime_error("Can't detect correct thread for auto_deleter_background.");
+    trace("Can't detect correct thread for auto_deleter_background.");
   }
 }
 

--- a/src/httprequest.cpp
+++ b/src/httprequest.cpp
@@ -599,10 +599,9 @@ void HttpRequest::close() {
 
   if (_is_closing) {
     trace("close() called twice on HttpRequest object");
-    // Shouldn't get here, but just in case close() gets called twice
-    // (probably via a scheduled callback), don't do the closing machinery
-    // twice.
-    _on_closed(NULL);
+    // We can get here in unusual cases when close() is called once directly,
+    // and another time via a scheduled callback. When this happens, don't do
+    // the closing machinery twice.
     return;
   }
   _is_closing = true;

--- a/src/httprequest.cpp
+++ b/src/httprequest.cpp
@@ -584,11 +584,23 @@ void HttpRequest::closeWSSocket() {
 void HttpRequest::_on_closed(uv_handle_t* handle) {
   ASSERT_BACKGROUND_THREAD()
   trace("HttpRequest::_on_closed");
+
+  boost::shared_ptr<WebSocketConnection> p_wsc = _pWebSocketConnection;
+  // It's possible for _pWebSocketConnection to have had its refcount drop to
+  // zero from another thread or earlier callback in this thread. If that
+  // happened, do nothing.
+  if (!p_wsc) {
+    return;
+  }
+
   // Tell the WebSocketConnection that the connection is closed, before
   // resetting the shared_ptr. This is useful because there may be some
   // callbacks that will execute later, and we want to make sure the WSC
   // doesn't try to do anything with them.
-  _pWebSocketConnection->markClosed();
+  p_wsc->markClosed();
+
+  // Note that this location and the destructor are the only places where
+  // _pWebSocketConnection is reset; both are on the background thread.
   _pWebSocketConnection.reset();
 }
 
@@ -606,14 +618,16 @@ void HttpRequest::close() {
   }
   _is_closing = true;
 
-  if (_protocol == WebSockets) {
+  boost::shared_ptr<WebSocketConnection> p_wsc = _pWebSocketConnection;
+
+  if (p_wsc && _protocol == WebSockets) {
     // Schedule:
-    // _pWebApplication->onWSClose(_pWebSocketConnection)
+    // _pWebApplication->onWSClose(p_wsc)
     invoke_later(
       boost::bind(
         &WebApplication::onWSClose,
         _pWebApplication,
-        _pWebSocketConnection
+        p_wsc
       )
     );
   }
@@ -769,7 +783,13 @@ void HttpRequest::_on_request_read(uv_stream_t*, ssize_t nread, const uv_buf_t* 
       this->_parse_http_data(buf->base, nread);
 
     } else if (_protocol == WebSockets) {
-      _pWebSocketConnection->read(buf->base, nread);
+      boost::shared_ptr<WebSocketConnection> p_wsc = _pWebSocketConnection;
+      // It's possible for _pWebSocketConnection to have had its refcount drop to
+      // zero from another thread or earlier callback in this thread. If that
+      // happened, do nothing.
+      if (p_wsc) {
+        p_wsc->read(buf->base, nread);
+      }
     }
   } else if (nread < 0) {
     if (nread == UV_EOF || nread == UV_ECONNRESET) {

--- a/src/httprequest.h
+++ b/src/httprequest.h
@@ -110,12 +110,7 @@ public:
   virtual ~HttpRequest() {
     ASSERT_BACKGROUND_THREAD()
     trace("HttpRequest::~HttpRequest");
-
-    try {
-      // Call reset instead of letting the lifetime end, because we want it
-      // inside a try-catch.
-      _pWebSocketConnection.reset();
-    } catch (...) {}
+    _pWebSocketConnection.reset();
   }
 
   uv_stream_t* handle();


### PR DESCRIPTION
This fixes #128.

Now when I do the procedure that previously caused a segfault, I get this output (when tracing is enabled in Makevars):

```
HttpRequest::_on_headers_complete
HttpRequest::sendWSFrame
on_ws_message_sent
HttpRequest::sendWSFrame
on_ws_message_sent
HttpRequest::close
HttpRequest::_on_closed
WebSocketConnection::~WebSocketConnection
WebSocketConnection::onFrameComplete
HttpRequest::closeWSSocket
HttpRequest::close
HttpRequest::onWSClose
HttpRequest::_on_closed
^CHttpRequest::schedule_close
HttpRequest::close
close() called twice on HttpRequest object            <-----
HttpRequest::_schedule_on_headers_complete_complete
HttpRequest::_on_headers_complete_complete
HttpRequest::_on_message_complete
RWebApplication::getResponse
HttpRequest::responseScheduled
HttpRequest::_on_message_complete_complete
HttpResponse::~HttpResponse
HttpRequest::~HttpRequest
^C
Warning message:
replacing previous import ‘dplyr::vars’ by ‘ggplot2::vars’ when loading ‘radiant.data’ 

Stopped Radiant
...
```

Notice that, like before, it says `close() called twice on HttpRequest object`, but it no longer crashes there.