### PR TITLE
Add lptread parameter to the build for ppc64le

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -19,6 +19,10 @@ endif
 ifeq ($(UNAME), OpenBSD)
 PKG_LIBS += -lkvm
 endif
+UNAME_ARCH=$(shell uname -m)
+ifeq ($(UNAME_ARCH), ppc64le)
+PKG_LIBS += -lpthread
+endif
 
 PKG_CPPFLAGS = $(C_VISIBILITY)
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -9,7 +9,7 @@ ifeq ($(UNAME), Darwin)
 FRAMEWORK = -framework CoreServices
 endif
 
-PKG_LIBS = ./libuv/.libs/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o $(FRAMEWORK)
+PKG_LIBS = ./libuv/.libs/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o $(FRAMEWORK) -pthread
 ifeq ($(UNAME), SunOS)
 PKG_LIBS += -lkstat -lsendfile -lsocket -lxnet
 endif
@@ -19,12 +19,8 @@ endif
 ifeq ($(UNAME), OpenBSD)
 PKG_LIBS += -lkvm
 endif
-UNAME_ARCH=$(shell uname -m)
-ifeq ($(UNAME_ARCH), ppc64le)
-PKG_LIBS += -lpthread
-endif
 
-PKG_CPPFLAGS = $(C_VISIBILITY)
+PKG_CPPFLAGS = $(C_VISIBILITY) -pthread
 
 # To avoid spurious warnings from `R CMD check --as-cran`, about compiler
 # warning flags like -Werror.


### PR DESCRIPTION
Without lpthread parameter specification, build of httpuv is failed on Power architecute (ppc64le)