### PR TITLE
Fix #133: Assertion failures when running on Fedora 28

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ httpuv 1.4.2.9000
 
 * Fixed [#127](https://github.com/rstudio/httpuv/issues/127): Compilation failed on some platforms because `NULL` was used instead of an `Rcpp::List`. ([#131](https://github.com/rstudio/httpuv/pulls/131))
 
-* Fixed [#133](https://github.com/rstudio/httpuv/issues/133): Assertion failures when running on Fedora 28.
+* Fixed [#133](https://github.com/rstudio/httpuv/issues/133): Assertion failures when running on Fedora 28. ([#136](https://github.com/rstudio/httpuv/pulls/136))
 
 httpuv 1.4.2
 ============

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ httpuv 1.4.2.9000
 
 * Fixed [#127](https://github.com/rstudio/httpuv/issues/127): Compilation failed on some platforms because `NULL` was used instead of an `Rcpp::List`. ([#131](https://github.com/rstudio/httpuv/pulls/131))
 
+* Fixed [#133](https://github.com/rstudio/httpuv/issues/133): Assertion failures when running on Fedora 28.
+
 httpuv 1.4.2
 ============
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -37,7 +37,7 @@ CONFIGURE_FLAGS="--quiet"
 # PKG_CPPFLAGS += -Wno-deprecated-declarations -Wno-parentheses
 # Fedora 28 defines _GLIBCXX_ASSERTIONS, so we better define it everywhere
 # to catch issues earlier.
-PKG_CPPFLAGS += -D_GLIBCXX_ASSERTIONS
+# PKG_CPPFLAGS += -D_GLIBCXX_ASSERTIONS
 
 
 $(SHLIB): libuv/.libs/libuv.a http-parser/http_parser.o sha1/sha1.o base64/base64.o

--- a/src/Makevars
+++ b/src/Makevars
@@ -32,6 +32,13 @@ CONFIGURE_FLAGS="--quiet"
 # Uncomment to enable printing of trace() messages
 # PKG_CPPFLAGS += -DDEBUG_TRACE
 
+#### Other flags ####
+# Uncomment to suppress lots of warnings on Fedora 28
+# PKG_CPPFLAGS += -Wno-deprecated-declarations -Wno-parentheses
+# Fedora 28 defines _GLIBCXX_ASSERTIONS, so we better define it everywhere
+# to catch issues earlier.
+PKG_CPPFLAGS += -D_GLIBCXX_ASSERTIONS
+
 
 $(SHLIB): libuv/.libs/libuv.a http-parser/http_parser.o sha1/sha1.o base64/base64.o
 

--- a/src/httprequest.cpp
+++ b/src/httprequest.cpp
@@ -562,9 +562,9 @@ void HttpRequest::sendWSFrame(const char* pHeader, size_t headerSize,
   pSend->pFooter = new std::vector<char>(pFooter, pFooter + footerSize);
 
   uv_buf_t buffers[3];
-  buffers[0] = uv_buf_init(&(*pSend->pHeader)[0], pSend->pHeader->size());
-  buffers[1] = uv_buf_init(&(*pSend->pData)[0], pSend->pData->size());
-  buffers[2] = uv_buf_init(&(*pSend->pFooter)[0], pSend->pFooter->size());
+  buffers[0] = uv_buf_init(safe_vec_addr(*pSend->pHeader), pSend->pHeader->size());
+  buffers[1] = uv_buf_init(safe_vec_addr(*pSend->pData), pSend->pData->size());
+  buffers[2] = uv_buf_init(safe_vec_addr(*pSend->pFooter), pSend->pFooter->size());
 
   // TODO: Handle return code
   uv_write(&pSend->writeReq, (uv_stream_t*)handle(), buffers, 3,
@@ -680,11 +680,11 @@ void HttpRequest::_call_r_on_ws_open() {
 
 
   // Schedule on background thread:
-  // p_wsc->read(&(*req_buffer)[0], req_buffer->size())
+  // p_wsc->read(safe_vec_addr(*req_buffer), req_buffer->size())
   boost::function<void (void)> cb(
     boost::bind(&WebSocketConnection::read,
       p_wsc,
-      &(*req_buffer)[0],
+      safe_vec_addr(*req_buffer),
       req_buffer->size()
     )
   );
@@ -770,7 +770,7 @@ void HttpRequest::_parse_http_data_from_buffer() {
   std::vector<char> req_buffer = _requestBuffer;
   _requestBuffer.clear();
 
-  this->_parse_http_data(&req_buffer[0], req_buffer.size());
+  this->_parse_http_data(safe_vec_addr(req_buffer), req_buffer.size());
 }
 
 void HttpRequest::_on_request_read(uv_stream_t*, ssize_t nread, const uv_buf_t* buf) {

--- a/src/httpresponse.cpp
+++ b/src/httpresponse.cpp
@@ -96,7 +96,7 @@ void HttpResponse::writeResponse() {
     }
   }
 
-  uv_buf_t headerBuf = uv_buf_init(&_responseHeader[0], _responseHeader.size());
+  uv_buf_t headerBuf = uv_buf_init(safe_vec_addr(_responseHeader), _responseHeader.size());
   uv_write_t* pWriteReq = (uv_write_t*)malloc(sizeof(uv_write_t));
   memset(pWriteReq, 0, sizeof(uv_write_t));
   // Pointer to shared_ptr

--- a/src/httpuv.cpp
+++ b/src/httpuv.cpp
@@ -179,7 +179,7 @@ void sendWSMessage(SEXP conn,
   boost::function<void (void)> cb(
     boost::bind(&WebSocketConnection::sendWSMessage, wsc,
       mode,
-      &(*str)[0],
+      safe_vec_addr(*str),
       str->size()
     )
   );

--- a/src/utils.h
+++ b/src/utils.h
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <stdarg.h>
 #include <string>
+#include <vector>
 #include "thread.h"
 
 // A callback for deleting objects on the main thread using later(). This is
@@ -58,6 +59,17 @@ inline void err_printf(const char *fmt, ...) {
 
 // For debugging. See Makevars for information on how to enable.
 void trace(const std::string& msg);
+
+// Indexing into an empty vector causes assertion failures on some platforms
+template <typename T>
+T* safe_vec_addr(std::vector<T>& vec) {
+  return vec.size() ? &vec[0] : NULL;
+}
+
+// Indexing into an empty vector causes assertion failures on some platforms
+inline const char* safe_str_addr(const std::string& str) {
+  return str.size() ? &str[0] : NULL;
+}
 
 
 #endif

--- a/src/websockets-hybi03.cpp
+++ b/src/websockets-hybi03.cpp
@@ -7,6 +7,8 @@ extern "C" {
 #include "md5.h"
 }
 
+#include "utils.h"
+
 bool calculateKeyValue(const std::string& key, uint32_t* pResult = NULL) {
   std::string trimmed = trim(key);
   uint32_t value = 0;
@@ -77,7 +79,7 @@ void WebSocketProto_HyBi03::handshake(const std::string& url,
   MD5_Update(&ctx, handshake, 16);
 
   pResponse->resize(16, 0);
-  MD5_Final(&(*pResponse)[0], &ctx);
+  MD5_Final(safe_vec_addr(*pResponse), &ctx);
 
   std::string origin;
   if (requestHeaders.find("sec-websocket-origin") != requestHeaders.end())

--- a/src/websockets-ietf.cpp
+++ b/src/websockets-ietf.cpp
@@ -1,5 +1,7 @@
 #include "websockets-ietf.h"
 
+#include "utils.h"
+
 #include "sha1/sha1.h"
 #include "base64/base64.hpp"
 
@@ -22,10 +24,10 @@ void WebSocketProto_IETF::handshake(const std::string& url,
   std::string clear = trim(key) + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
   SHA1_CTX ctx;
   reid_SHA1_Init(&ctx);
-  reid_SHA1_Update(&ctx, (uint8_t*)&clear[0], clear.size());
+  reid_SHA1_Update(&ctx, (const uint8_t*)safe_str_addr(clear), clear.size());
 
   std::vector<uint8_t> digest(SHA1_DIGEST_SIZE);
-  reid_SHA1_Final(&ctx, &digest[0]);
+  reid_SHA1_Final(&ctx, safe_vec_addr(digest));
 
   std::string response = b64encode(digest.begin(), digest.end());
 


### PR DESCRIPTION
The issue was due to an idiom we were using all over the place, to get a pointer to the head of a `std::vector`:

```cpp
std::vector<char> buf;
char* pBuf = &buf[0];
```

This fails on Fedora 28 due to `_GLIBCXX_ASSERTIONS` being defined, which causes `std::vector` to range check on indexing operations.

### Test notes

Use this Dockerfile:

```
FROM fedora:latest

RUN dnf install -y R pandoc gdb
# If you have weird compile problems, it might be because -j4 causes the container
# to run out of memory. You can reduce the number or coment this out if needed.
RUN echo "MAKEFLAGS=-j4" > ~/.Renviron
RUN R -e "install.packages('shiny', repos = c(CRAN='https://cloud.r-project.org'), INSTALL_opts = '--no-help --no-html')"
```

Build the docker image:

```
docker build -t r-fedora .
```

Run the docker image:

```
docker run --rm -ti -p 4321:4321 --security-opt seccomp=unconfined r-fedora /bin/bash
```

Run a Shiny app using:

```bash
R --quiet -e 'shiny::runExample("01_hello", host = "0.0.0.0", port = 4321L, launch.browser = FALSE)'
```

Then launch a web browser and point it to http://localhost:4321. It should fail and crash R.

Now install the fix:

```r
R --quiet -e 'install.packages("remotes", repos = c(CRAN="https://cloud.r-project.org")); remotes::install_github("rstudio/httpuv@joe/bugfix/safe-addr")'
```

and run the Shiny app again. This time it should work.