### PR TITLE
wip for #134

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ httpuv 1.4.2.9000
 
 * Fixed [#133](https://github.com/rstudio/httpuv/issues/133): Assertion failures when running on Fedora 28. ([#136](https://github.com/rstudio/httpuv/pulls/136))
 
+* Fixed [#134](https://github.com/rstudio/httpuv/issues/134): Sanitizer complains when starting app after a failed app start. ([#138](https://github.com/rstudio/httpuv/pull/138))
+
 httpuv 1.4.2
 ============
 

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -140,6 +140,7 @@ uv_stream_t* createTcpServer(uv_loop_t* pLoop, const std::string& host,
   }
 
   if (r) {
+    // It's important that close() is explicitly called, so that the uv_tcp_t is cleaned up
     pSocket->close();
     return NULL;
   }
@@ -147,11 +148,13 @@ uv_stream_t* createTcpServer(uv_loop_t* pLoop, const std::string& host,
   r = uv_tcp_bind(&pSocket->handle.tcp, pAddress, 0);
 
   if (r) {
+    // It's important that close() is explicitly called, so that the uv_tcp_t is cleaned up
     pSocket->close();
     return NULL;
   }
   r = uv_listen((uv_stream_t*)&pSocket->handle.stream, 128, &on_request);
   if (r) {
+    // It's important that close() is explicitly called, so that the uv_tcp_t is cleaned up
     pSocket->close();
     return NULL;
   }

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -101,10 +101,6 @@ void createPipeServerSync(uv_loop_t* loop, const std::string& name,
   blocker->wait();
 }
 
-void close_complete_cb(uv_handle_t* handle) {
-  delete (boost::shared_ptr<Socket>*)handle->data;
-}
-
 uv_stream_t* createTcpServer(uv_loop_t* pLoop, const std::string& host,
   int port, boost::shared_ptr<WebApplication> pWebApplication,
   CallbackQueue* background_queue)
@@ -144,19 +140,19 @@ uv_stream_t* createTcpServer(uv_loop_t* pLoop, const std::string& host,
   }
 
   if (r) {
-    uv_close((uv_handle_t*)&pSocket->handle.stream, close_complete_cb);
+    pSocket->close();
     return NULL;
   }
 
   r = uv_tcp_bind(&pSocket->handle.tcp, pAddress, 0);
 
   if (r) {
-    uv_close((uv_handle_t*)&pSocket->handle.stream, close_complete_cb);
+    pSocket->close();
     return NULL;
   }
   r = uv_listen((uv_stream_t*)&pSocket->handle.stream, 128, &on_request);
   if (r) {
-    uv_close((uv_handle_t*)&pSocket->handle.stream, close_complete_cb);
+    pSocket->close();
     return NULL;
   }
 

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -101,6 +101,9 @@ void createPipeServerSync(uv_loop_t* loop, const std::string& name,
   blocker->wait();
 }
 
+void close_complete_cb(uv_handle_t* handle) {
+  delete (boost::shared_ptr<Socket>*)handle->data;
+}
 
 uv_stream_t* createTcpServer(uv_loop_t* pLoop, const std::string& host,
   int port, boost::shared_ptr<WebApplication> pWebApplication,
@@ -141,19 +144,19 @@ uv_stream_t* createTcpServer(uv_loop_t* pLoop, const std::string& host,
   }
 
   if (r) {
-    delete (boost::shared_ptr<Socket>*)pSocket->handle.stream.data;
+    uv_close((uv_handle_t*)&pSocket->handle.stream, close_complete_cb);
     return NULL;
   }
 
   r = uv_tcp_bind(&pSocket->handle.tcp, pAddress, 0);
 
   if (r) {
-    delete (boost::shared_ptr<Socket>*)pSocket->handle.stream.data;
+    uv_close((uv_handle_t*)&pSocket->handle.stream, close_complete_cb);
     return NULL;
   }
   r = uv_listen((uv_stream_t*)&pSocket->handle.stream, 128, &on_request);
   if (r) {
-    delete (boost::shared_ptr<Socket>*)pSocket->handle.stream.data;
+    uv_close((uv_handle_t*)&pSocket->handle.stream, close_complete_cb);
     return NULL;
   }
 


### PR DESCRIPTION
AddressSanitizer was right, this appears to be a legitimate use-after-free. When `uv_tcp_init` is called, it adds a reference to the handle to `uv_loop_t`. https://github.com/rstudio/httpuv/blob/248723576422281b9a039b336f2df3cff6967d20/src/libuv/src/uv-common.h#L216

This reference doesn't get removed until after `uv_close` asynchronously completes. https://github.com/rstudio/httpuv/blob/5d1b7efc01dabfb373ee5e71830e59a2bde30236/src/libuv/src/unix/core.c#L283

We were not calling `uv_close` in case of error. The subsequent call to `uv_tcp_init` causes the next tcp handle to be added to `uv_loop_t`, and traversing the list of references causes the sanitizer alarms to be tripped.