### PR TITLE
Before closing handle, make sure it is not already in closing state

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 httpuv 1.4.3.9001
 =================
 
+* Fixed [#144](https://github.com/rstudio/httpuv/issues/144): Before closing a handle, make sure that it is not already closing. ([#145](https://github.com/rstudio/httpuv/pull/145))
+
 * Exported `ipFamily()` function, which tests whether a string represents an IPv4 address, IPv6 address, or neither. ([#142](https://github.com/rstudio/httpuv/pull/142))
 
 * Templated C++ code with the format `A<B<C>>` has been changed to `A<B<C> >`. Allowing consecutive `>>` is a feature of C++11.

--- a/src/httpuv.cpp
+++ b/src/httpuv.cpp
@@ -83,7 +83,9 @@ uv_async_t async_stop_io_loop;
 
 void close_handle_cb(uv_handle_t* handle, void* arg) {
   ASSERT_BACKGROUND_THREAD()
-  uv_close(handle, NULL);
+  if (!uv_is_closing(handle)) {
+    uv_close(handle, NULL);
+  }
 }
 
 void stop_io_loop(uv_async_t *handle) {


### PR DESCRIPTION
This fixes #144. On Windows, calling `uv_close()` on a handle does not close it immediately, but first puts it into a closing state. This makes sure we don't try to close it twice.

See here for an example:
https://github.com/joyent/libuv/blob/master/test/task.h#L222-L225