### PR TITLE
Make sure configure script is executable. Fixes #151

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,9 @@ httpuv 1.4.3.9002
 
 * Fixed [#147](https://github.com/rstudio/httpuv/issues/147): Santizer complained when starting app with `startPipeServer` after a failed app start. ([#149](https://github.com/rstudio/httpuv/pull/149))
 
+* Fixed [#150](https://github.com/rstudio/httpuv/issues/150), [#151](https://github.com/rstudio/httpuv/issues/151): On some platforms, httpuv would fail to install from a zip file because R's `unzip()` function did not preserve the executable permission for `src/libuv/configure`. ([#152](https://github.com/rstudio/httpuv/pull/152))
+
+
 httpuv 1.4.3
 ============
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -48,7 +48,9 @@ libuv/m4/lt~obsolete.m4: libuv/m4/lt_obsolete.m4
 	cp -p -f libuv/m4/lt_obsolete.m4 libuv/m4/lt~obsolete.m4
 
 # Run ./configure. We need to touch various autotools-related files to avoid
-# it trying to run autotools programs again.
+# it trying to run autotools programs again. We also need to make sure
+# configure is executable, because on some platforms, calling unzip() in R
+# does not preserve the executable bit.
 #
 # It's VERY IMPORTANT that mtime(aclocal.m4) <= mtime(configure), and also
 # mtime(aclocal.m4) <= mtime(Makefile.in). On some platforms, passing multiple
@@ -61,6 +63,7 @@ libuv/Makefile: libuv/m4/lt~obsolete.m4
 	(cd libuv \
 		&& touch aclocal.m4 \
 		&& touch -r aclocal.m4 configure Makefile.in \
+		&& chmod +x configure \
 		&& CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(C_VISIBILITY)" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure $(CONFIGURE_FLAGS))
 
 libuv/.libs/libuv.a: libuv/Makefile


### PR DESCRIPTION
This fixes #151. This works on rstudio.cloud:

```R
remotes::install_github("rstudio/httpuv@fix-configure-perms")
```