### PR TITLE
Be lenient about Connection header contents when Upgrade header is present

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ httpuv 1.4.3.9002
 
 * Fixed [#150](https://github.com/rstudio/httpuv/issues/150), [#151](https://github.com/rstudio/httpuv/issues/151): On some platforms, httpuv would fail to install from a zip file because R's `unzip()` function did not preserve the executable permission for `src/libuv/configure`. ([#152](https://github.com/rstudio/httpuv/pull/152))
 
+* Worked around an issue where Shiny apps couldn't be viewed when launched from RStudio Server using Firefox. ([#153](https://github.com/rstudio/httpuv/pull/153))
 
 httpuv 1.4.3
 ============

--- a/src/httprequest.h
+++ b/src/httprequest.h
@@ -126,7 +126,9 @@ public:
   std::string method() const;
   std::string url() const;
   const RequestHeaders& headers() const;
-
+  // Is the request an Upgrade (i.e. WebSocket connection)?
+  bool isUpgrade() const;
+  
   void sendWSFrame(const char* pHeader, size_t headerSize,
                    const char* pData, size_t dataSize,
                    const char* pFooter, size_t footerSize);


### PR DESCRIPTION
This is a workaround for https://github.com/rstudio/rstudio/issues/2940. It
stops an erroneously sent "Connection: close" header from breaking an
otherwise legit websocket request.