### PR TITLE
Remove _GLIBCXX_ASSERTIONS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     Rcpp (>= 0.11.0),
     utils,
     promises,
-    later (>= 0.7.2)
+    later (>= 0.7.3)
 LinkingTo: Rcpp, BH, later
 URL: https://github.com/rstudio/httpuv
 SystemRequirements: GNU make

--- a/src/Makevars
+++ b/src/Makevars
@@ -37,7 +37,9 @@ CONFIGURE_FLAGS="--quiet"
 # PKG_CPPFLAGS += -Wno-deprecated-declarations -Wno-parentheses
 # Fedora 28 defines _GLIBCXX_ASSERTIONS, so we better define it everywhere
 # to catch issues earlier.
-PKG_CPPFLAGS += -D_GLIBCXX_ASSERTIONS
+# jcheng 2018-06-18: Disabling _GLIBCXX_ASSERTIONS for now, as it causes
+#   CRAN to flag the package as using abort and printf.
+# PKG_CPPFLAGS += -D_GLIBCXX_ASSERTIONS
 
 
 $(SHLIB): libuv/.libs/libuv.a http-parser/http_parser.o sha1/sha1.o base64/base64.o


### PR DESCRIPTION
Caused CRAN rejection, due to `printf` and `abort` being introduced.

Also requiring later 0.7.3, which is now on CRAN and fixes a crash on Windows.