### PR TITLE
Fix Windows build for gcc 8.1.0

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -4,11 +4,10 @@ CXX_STD=CXX11
 PKG_LIBS = ./libuv/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o \
 	-lpthread -lws2_32 -lkernel32 -lpsapi -liphlpapi -lshell32 -luserenv
 
-PKG_CPPFLAGS += -D_WIN32_WINNT=0x0600 -DSTRICT_R_HEADERS
-CFLAGS += -D_WIN32_WINNT=0x0600 -DSTRICT_R_HEADERS
+PKG_CPPFLAGS += -D_WIN32_WINNT=0x0600 -DSTRICT_R_HEADERS -Wno-deprecated
 
 # Additional flags for libuv borrowed from libuv/Makefile.mingw
-LIBUV_CFLAGS = -Iinclude -Isrc -Isrc/win -DWIN32_LEAN_AND_MEAN
+LIBUV_CFLAGS = -Iinclude -Isrc -Isrc/win -DWIN32_LEAN_AND_MEAN -D_WIN32_WINNT=0x0600
 
 #### Debugging flags ####
 # Uncomment to enable thread assertions


### PR DESCRIPTION
The new Windows toolchain requires that `libuv` is compiled with ` -D_WIN32_WINNT=0x0600`. I also cleaned up some other flags while I was at it.