### PR TITLE
Make sure connection is not upgraded too early

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: httpuv
 Type: Package
 Title: HTTP and WebSocket Server Library
-Version: 1.4.4.2
+Version: 1.4.4.9001
 Author: Joe Cheng, Hector Corrada Bravo [ctb], Jeroen Ooms [ctb],
     Winston Chang [ctb]
 Copyright: RStudio, Inc.; Joyent, Inc.; Nginx Inc.; Igor Sysoev; Niels Provos;

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+httpuv 1.4.4.9001
+==============
+
+* Fixed [#161](https://github.com/rstudio/httpuv/issues/161): An HTTP connection could get upgraded to a WebSocket too early, which sometimes resulted in closed connections. ([#162](https://github.com/rstudio/httpuv/pull/162))
+
 httpuv 1.4.4.2
 ==============
 

--- a/src/httprequest.h
+++ b/src/httprequest.h
@@ -60,6 +60,10 @@ private:
 
   bool _is_closing;
 
+  // This starts false, and in the case of a connection upgrade, gets set to
+  // true after the headers are complete.
+  bool _is_upgrade;
+
   bool _hasHeader(const std::string& name) const;
   bool _hasHeader(const std::string& name, const std::string& value, bool ci = false) const;
 
@@ -92,6 +96,7 @@ public:
       _protocol(HTTP),
       _ignoreNewData(false),
       _is_closing(false),
+      _is_upgrade(false),
       _response_scheduled(false),
       _handling_request(false),
       _background_queue(backgroundQueue)
@@ -126,6 +131,7 @@ public:
   std::string method() const;
   std::string url() const;
   const RequestHeaders& headers() const;
+
   // Is the request an Upgrade (i.e. WebSocket connection)?
   bool isUpgrade() const;
   
@@ -168,6 +174,10 @@ public:
 
   virtual void onWSMessage(bool binary, const char* data, size_t len);
   virtual void onWSClose(int code);
+
+  // Update whether or not this HttpRequest is to be upgraded. This is called
+  // from _on_headers_complete().
+  void updateUpgradeStatus();
 
   void fatal_error(const char* method, const char* message);
   void _on_closed(uv_handle_t* handle);


### PR DESCRIPTION
This fixes #161. This makes sure that a HTTP connection is not upgraded too early, before all the request headers have been processed.

In the old http-parser code, `parser->upgrade` was set in the `s_headers_almost_done` stage (https://github.com/rstudio/httpuv/blob/v1.3.6.2/src/http-parser/http_parser.c#L1567-L1568). This happens when all the request headers have been processed.

Also, in the current version of http-parser, `parser->upgrade` is set in `s_headers_almost_done` (https://github.com/rstudio/httpuv/blob/c3978bad/src/http-parser/http_parser.c#L1822-L1825) or in `s_on_headers_completed` (https://github.com/rstudio/httpuv/blob/c3978bad/src/http-parser/http_parser.c#L1884).

In #153, we added `isUpgrade()`. The problem is that it could return `true` before all the headers have been processed. This PR makes sure that `isUpgrade()` will return `true` only after all the headers have been processed.

One thing that I'm not 100% sure about: In the http-parser code, `parser->upgrade` could be set in a slightly earlier stage (`s_headers_almost_done`) than what I've done here (`HttpRequest:: _on_headers_complete`), and I wonder if that could result in different behavior.