### PR TITLE
Block SIGPIPE on background thread

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 httpuv 1.4.5.9000
 ============
 
+* Fixed [#168](https://github.com/rstudio/httpuv/issues/168): A SIGPIPE signal on the httpuv background thread could cause the process to quit. This can happen in some instances when the server is under heavy load. ([#169](https://github.com/rstudio/httpuv/pull/169))
 
 httpuv 1.4.5
 ============


### PR DESCRIPTION
This (hopefully) fixes #168. @shapenaji, @atheriel, can you try installing this and see if it fixes trestletech/plumber#289?

***** 
Note: The `pthread_sigmask()` documentation wasn't clear about what exactly would happen if a blocked signal is sent to the thread -- would the signal be then sent to another available thread? I wrote the program below to test it out and found that no, the signal does not get sent to another thread (which is what we want).


```C
#include <pthread.h>
#include <stdio.h>
#include <signal.h>


void block_sigpipe() {
  sigset_t set;
  int result;
  sigemptyset(&set);
  sigaddset(&set, SIGPIPE);
  fprintf(stderr, "Blocking SIGPIPE on thread.\n");
  result = pthread_sigmask(SIG_BLOCK, &set, NULL);
  if (result) {
    fprintf(stderr, "Error blocking SIGPIPE.\n");
  }
}

void* bg_func(void* data) {
  fprintf(stderr, "Started bg thread\n");

  // Comment out this line to see behavior if signal is not blocked
  block_sigpipe();

  fprintf(stderr, "Signalling SIGPIPE to thread... ");
  pthread_kill(pthread_self(), SIGPIPE);
  fprintf(stderr, "done\n");

  return NULL;
}

int main(int argc, char ** argv) {
  pthread_t bg_thread;

  if (pthread_create(&bg_thread, NULL, bg_func, NULL)) {
    fprintf(stderr, "Error creating thread.\n");
    return 1;
  }

  // Wait for thread to finish.
  if (pthread_join(bg_thread, NULL)) {
    fprintf(stderr, "Error joining thread.\n");
    return 2;
  }

  // If it gets here, then the SIGPIPE did not get sent to the main thread.
  fprintf(stderr, "Joined thread. Exiting.\n");

  return 0;
}
```