### PR TITLE
Windows static file serving: return 404 when path component is missing

### DIFF
--- a/src/filedatasource-win.cpp
+++ b/src/filedatasource-win.cpp
@@ -25,7 +25,7 @@ FileDataSourceResult FileDataSource::initialize(const std::string& path, bool ow
                       NULL);
 
   if (_hFile == INVALID_HANDLE_VALUE) {
-    if (GetLastError() == ERROR_FILE_NOT_FOUND) {
+    if (GetLastError() == ERROR_FILE_NOT_FOUND || GetLastError() == ERROR_PATH_NOT_FOUND) {
       _lastErrorMessage = "File does not exist: " + path + "\n";
       return FDS_NOT_EXIST;
 

--- a/tests/testthat/test-static-paths.R
+++ b/tests/testthat/test-static-paths.R
@@ -63,6 +63,14 @@ test_that("Basic static file serving", {
   # Missing file (404)
   r <- fetch(local_url("/foo", s$getPort()))
   h <- parse_headers_list(r$headers)
+  expect_equal(r$status_code, 404)
+  expect_identical(rawToChar(r$content), "404 Not Found\n")
+  expect_equal(h$`content-length`, "14")
+
+  # Missing directory in path (404)
+  r <- fetch(local_url("/foo/bar", s$getPort()))
+  h <- parse_headers_list(r$headers)
+  expect_equal(r$status_code, 404)
   expect_identical(rawToChar(r$content), "404 Not Found\n")
   expect_equal(h$`content-length`, "14")
 


### PR DESCRIPTION
This fixes #187.