### PR TITLE
Validate header in constant time

### DIFF
--- a/src/staticpath.cpp
+++ b/src/staticpath.cpp
@@ -128,7 +128,7 @@ bool StaticPathOptions::validateRequestHeaders(const RequestHeaders& headers) co
   }
 
   RequestHeaders::const_iterator it = headers.find(pattern[1]);
-  if (it != headers.end() && it->second == pattern[2]) {
+  if (it != headers.end() && constant_time_compare(it->second, pattern[2])) {
     return true;
   }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -308,4 +308,23 @@ inline time_t parse_http_date_string(const std::string& date) {
   return to_time_t(pt);
 }
 
+// Compares two strings in constant time. Returns true if they are the same;
+// false otherwise.
+inline bool constant_time_compare(const std::string& a, const std::string& b) {
+  if (a.length() != b.length())
+    return false;
+
+  const char* ac = a.c_str();
+  const char* bc = b.c_str();
+
+  bool identical = true;
+  for (int i=0; i<a.length(); i++) {
+    if (ac[i] != bc[i]) {
+      identical = false;
+    }
+  }
+
+  return identical;
+}
+
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -314,17 +314,16 @@ inline bool constant_time_compare(const std::string& a, const std::string& b) {
   if (a.length() != b.length())
     return false;
 
-  const char* ac = a.c_str();
-  const char* bc = b.c_str();
+  volatile const char* ac = a.c_str();
+  volatile const char* bc = b.c_str();
+  volatile char result = 0;
+  int len = a.length();
 
-  bool identical = true;
-  for (int i=0; i<a.length(); i++) {
-    if (ac[i] != bc[i]) {
-      identical = false;
-    }
+  for (int i=0; i<len; i++) {
+    result |= ac[i] ^ bc[i];
   }
 
-  return identical;
+  return (result == 0);
 }
 
 #endif


### PR DESCRIPTION
Closes #191.

Note that the the header validation code has tests at https://github.com/rstudio/httpuv/blob/1ca8f15c/tests/testthat/test-static-paths.R#L231-L314, and they still pass.