### PR TITLE
Make sure that pointer refers to allocated memory

### DIFF
--- a/src/httpuv.cpp
+++ b/src/httpuv.cpp
@@ -628,8 +628,7 @@ Rcpp::CharacterVector decodeURI(Rcpp::CharacterVector value) {
   for (int i = 0; i < value.size(); i++) {
     if (value[i] != NA_STRING) {
       std::string decoded = doDecodeURI(Rcpp::as<std::string>(value[i]), false);
-      const char* s = decoded.c_str();
-      out[i] = Rf_mkCharCE(s, CE_UTF8);
+      out[i] = Rf_mkCharLenCE(decoded.c_str(), decoded.length(), CE_UTF8);
     }
   }
 
@@ -645,8 +644,7 @@ Rcpp::CharacterVector decodeURIComponent(Rcpp::CharacterVector value) {
   for (int i = 0; i < value.size(); i++) {
     if (value[i] != NA_STRING) {
       std::string decoded = doDecodeURI(Rcpp::as<std::string>(value[i]), true);
-      const char* s = decoded.c_str();
-      out[i] = Rf_mkCharCE(s, CE_UTF8);
+      out[i] = Rf_mkCharLenCE(decoded.c_str(), decoded.length(), CE_UTF8);
     }
   }
 

--- a/src/httpuv.cpp
+++ b/src/httpuv.cpp
@@ -627,7 +627,8 @@ Rcpp::CharacterVector decodeURI(Rcpp::CharacterVector value) {
 
   for (int i = 0; i < value.size(); i++) {
     if (value[i] != NA_STRING) {
-      const char* s = doDecodeURI(Rcpp::as<std::string>(value[i]), false).c_str();
+      std::string decoded = doDecodeURI(Rcpp::as<std::string>(value[i]), false);
+      const char* s = decoded.c_str();
       out[i] = Rf_mkCharCE(s, CE_UTF8);
     }
   }
@@ -643,7 +644,8 @@ Rcpp::CharacterVector decodeURIComponent(Rcpp::CharacterVector value) {
 
   for (int i = 0; i < value.size(); i++) {
     if (value[i] != NA_STRING) {
-      const char* s = doDecodeURI(Rcpp::as<std::string>(value[i]), true).c_str();
+      std::string decoded = doDecodeURI(Rcpp::as<std::string>(value[i]), true);
+      const char* s = decoded.c_str();
       out[i] = Rf_mkCharCE(s, CE_UTF8);
     }
   }


### PR DESCRIPTION
This fixes #198.

`decodeURI` and `decodeURIComponent` now consistently return the same (correct) value.

```R
table(httpuv::decodeURI(rep("12345678901234567890123", 10000)))
#> 
#> 12345678901234567890123 
#>                   10000
table(httpuv::decodeURIComponent(rep("12345678901234567890123", 10000)))
#> 
#> 12345678901234567890123 
#>                   10000
```