### PR TITLE
Fix empty translation unit warning

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -24,6 +24,8 @@ To update libuv to a new version, do the following:
     ```
     # Fix for unnamed structs on MinGW
     git cherry-pick 327a0a9
+    # Fix for empty translation unit warning on Windows with -pedantic
+    git cherry-pick 7088089
     # Fix for Solaris
     git cherry-pick f7b4ff8
     ```
@@ -72,6 +74,12 @@ Because it's not possible to run the configure script from `R CMD INSTALL`, http
 #### MinGW and unnamed structs
 
 The libuv sources contain unnamed structs, which result in warnings on MinGW's GCC. This in turn causes WARNINGS in R CMD check on Windows. They were converted to named structs.
+
+#### Empty translation unit
+
+When libuv/src/win/snprintf.c is compiled, the entire content of the file is `#ifdef`-ed out, so the result is empty. When compiled with the `-pedantic` flag, as is done on CRAN's win-builder service (and probably the CRAN build machine), this results in a significant warning.
+
+The workaround just adds a dummy `typedef` statement to suppress the warning.
 
 #### Solaris support
 

--- a/src/libuv/src/win/snprintf.c
+++ b/src/libuv/src/win/snprintf.c
@@ -40,3 +40,8 @@ int snprintf(char* buf, size_t len, const char* fmt, ...) {
 }
 
 #endif
+
+/* Workaround for "ISO C forbids an empty translation unit" when compiled with
+ * -pedantic. This is flagged as a significant warning by R CMD check.
+ */
+typedef int make_iso_compilers_happy;


### PR DESCRIPTION
When the 1.5.0 RC was sent to win-builder, it had a significant warning:

```
* checking whether package 'httpuv' can be installed ... WARNING
Found the following significant warnings:
  src/win/snprintf.c:42:0: warning: ISO C forbids an empty translation unit [-Wpedantic]
See 'd:/RCompile/CRANguest/R-devel/httpuv.Rcheck/00install.out' for details.
```

This PR makes the warning go away, using the technique from here: https://stackoverflow.com/a/26541331/412655