### PR TITLE
Allocate one extra byte for snprintf

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -233,7 +233,7 @@ inline std::string http_date_string(const time_t& t) {
   }
 
   const int maxlen = 30;
-  char res[maxlen];
+  char res[maxlen + 1];
   snprintf(res, maxlen, "%s, %02d %s %04d %02d:%02d:%02d GMT",
     day_name.c_str(),
     timeptr.tm_mday,

--- a/src/utils.h
+++ b/src/utils.h
@@ -232,8 +232,8 @@ inline std::string http_date_string(const time_t& t) {
     default: return "";
   }
 
-  const int maxlen = 30;
-  char res[maxlen + 1];
+  const int maxlen = 50;
+  char res[maxlen];
   snprintf(res, maxlen, "%s, %02d %s %04d %02d:%02d:%02d GMT",
     day_name.c_str(),
     timeptr.tm_mday,


### PR DESCRIPTION
This fixes a significant warning on CRAN's win-builder:

```
In file included from websockets.h:12,
                 from webapplication.h:7,
                 from webapplication.cpp:6:
utils.h: In function ‘std::__cxx11::string http_date_string(const time_t&)’:
utils.h:237:25: warning: ‘snprintf’ output may be truncated before the last format character [-Wformat-truncation=]
   snprintf(res, maxlen, "%s, %02d %s %04d %02d:%02d:%02d GMT",
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
utils.h:237:11: note: ‘snprintf’ output 24 or more bytes (assuming 31) into a destination of size 30
   snprintf(res, maxlen, "%s, %02d %s %04d %02d:%02d:%02d GMT",
   ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     day_name.c_str(),
     ~~~~~~~~~~~~~~~~~
     timeptr.tm_mday,
     ~~~~~~~~~~~~~~~~
     month_name.c_str(),
     ~~~~~~~~~~~~~~~~~~~
     timeptr.tm_year + 1900,
     ~~~~~~~~~~~~~~~~~~~~~~~
     timeptr.tm_hour,
     ~~~~~~~~~~~~~~~~
     timeptr.tm_min,
     ~~~~~~~~~~~~~~~
     timeptr.tm_sec
     ~~~~~~~~~~~~~~
   );
   ~        
```
