### PR TITLE
Fixes for RHEL/Centos 6

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+httpuv 1.5.0.9000
+============
+
+* Fixed issues for compilers that didn't support C++11, notably on RHEL and Centos 6. ([#210](https://github.com/rstudio/httpuv/pull/210))
+
 httpuv 1.5.0
 ============
 

--- a/src/filedatasource.h
+++ b/src/filedatasource.h
@@ -21,7 +21,7 @@ class FileDataSource : public DataSource {
   int _fd;
   off_t _length;
 #endif
-  std::string _lastErrorMessage = "";
+  std::string _lastErrorMessage;
 
 public:
   FileDataSource() {}

--- a/src/httprequest.cpp
+++ b/src/httprequest.cpp
@@ -299,7 +299,7 @@ int HttpRequest::_on_headers_complete(http_parser* pParser) {
   updateUpgradeStatus();
 
   // Attempt static serving here. If the request is for a static path, this
-  // will be a response object; if not, it will be nullptr.
+  // will be a response object; if not, it will be an empty shared_ptr.
   boost::shared_ptr<HttpResponse> pResponse =
     _pWebApplication->staticFileResponse(shared_from_this());
 
@@ -393,7 +393,7 @@ void HttpRequest::_on_headers_complete_complete(boost::shared_ptr<HttpResponse> 
     if (hasHeader("Expect", "100-continue")) {
       pResponse = boost::shared_ptr<HttpResponse>(
         new HttpResponse(shared_from_this(), 100, "Continue",
-                         boost::shared_ptr<DataSource>(nullptr)),
+                         boost::shared_ptr<DataSource>()),
         auto_deleter_background<HttpResponse>
       );
       pResponse->writeResponse();

--- a/src/staticpath.cpp
+++ b/src/staticpath.cpp
@@ -39,7 +39,7 @@ StaticPathOptions::StaticPathOptions(const Rcpp::List& options) :
   temp = options["fallthrough"];  fallthrough  = optional_as<bool>(temp);
   temp = options["html_charset"]; html_charset = optional_as<std::string>(temp);
   temp = options["headers"];      headers      = optional_as<ResponseHeaders>(temp);
-  temp = options["validation"];   validation   = optional_as<std::vector<std::string>>(temp);
+  temp = options["validation"];   validation   = optional_as<std::vector<std::string> >(temp);
   temp = options["exclude"];      exclude      = optional_as<bool>(temp);
 }
 
@@ -74,7 +74,7 @@ void StaticPathOptions::setOptions(const Rcpp::List& options) {
   if (options.containsElementNamed("validation")) {
     temp = options["validation"];
     if (!temp.isNULL()) {
-      validation = optional_as<std::vector<std::string>>(temp);
+      validation = optional_as<std::vector<std::string> >(temp);
     }
   }
   if (options.containsElementNamed("exclude")) {
@@ -290,7 +290,7 @@ void StaticPathManager::remove(const std::vector<std::string>& paths) {
 
 void StaticPathManager::remove(const Rcpp::CharacterVector& paths) {
   ASSERT_MAIN_THREAD()
-  std::vector<std::string> paths_vec = Rcpp::as<std::vector<std::string>>(paths);
+  std::vector<std::string> paths_vec = Rcpp::as<std::vector<std::string> >(paths);
   remove(paths_vec);
 }
 
@@ -315,7 +315,7 @@ void StaticPathManager::remove(const Rcpp::CharacterVector& paths) {
 //
 // If no matching static path is found, then it returns boost::none.
 //
-boost::optional<std::pair<StaticPath, std::string>> StaticPathManager::matchStaticPath(
+boost::optional<std::pair<StaticPath, std::string> > StaticPathManager::matchStaticPath(
   const std::string& url_path) const
 {
 

--- a/src/staticpath.cpp
+++ b/src/staticpath.cpp
@@ -275,7 +275,7 @@ void StaticPathManager::set(const Rcpp::List& pmap) {
 
 void StaticPathManager::remove(const std::string& path) {
   guard guard(mutex);
-  std::map<std::string, StaticPath>::const_iterator it = path_map.find(path);
+  std::map<std::string, StaticPath>::iterator it = path_map.find(path);
   if (it != path_map.end()) {
     path_map.erase(it);
   }

--- a/src/staticpath.h
+++ b/src/staticpath.h
@@ -14,7 +14,7 @@ public:
   boost::optional<bool> fallthrough;
   boost::optional<std::string> html_charset;
   boost::optional<ResponseHeaders> headers;
-  boost::optional<std::vector<std::string>> validation;
+  boost::optional<std::vector<std::string> > validation;
   boost::optional<bool> exclude;
   StaticPathOptions() :
     indexhtml(boost::none),
@@ -69,7 +69,7 @@ public:
   void remove(const std::vector<std::string>& paths);
   void remove(const Rcpp::CharacterVector& paths);
 
-  boost::optional<std::pair<StaticPath, std::string>> matchStaticPath(
+  boost::optional<std::pair<StaticPath, std::string> > matchStaticPath(
     const std::string& url_path) const;
 
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -149,7 +149,7 @@ Rcpp::RObject optional_wrap(boost::optional<T> value) {
 // (constants.h doesn't include Rcpp.h so we can't define these functions
 // there.)
 namespace Rcpp {
-  template <> inline std::vector<std::pair<std::string, std::string>> as(SEXP x) {
+  template <> inline std::vector<std::pair<std::string, std::string> > as(SEXP x) {
     ASSERT_MAIN_THREAD()
     Rcpp::CharacterVector headers(x);
     Rcpp::CharacterVector names = headers.names();
@@ -158,7 +158,7 @@ namespace Rcpp {
       throw Rcpp::exception("All values must be named.");
     }
 
-    std::vector<std::pair<std::string, std::string>> result;
+    std::vector<std::pair<std::string, std::string> > result;
 
     for (int i=0; i<headers.size(); i++) {
       std::string name = Rcpp::as<std::string>(names[i]);
@@ -174,7 +174,7 @@ namespace Rcpp {
     return result;
   }
 
-  template <> inline SEXP wrap(const std::vector<std::pair<std::string, std::string>> &x) {
+  template <> inline SEXP wrap(const std::vector<std::pair<std::string, std::string> > &x) {
     ASSERT_MAIN_THREAD()
 
     std::vector<std::string> values(x.size());

--- a/src/webapplication.cpp
+++ b/src/webapplication.cpp
@@ -190,8 +190,7 @@ boost::shared_ptr<HttpResponse> listToResponse(
   using namespace Rcpp;
 
   if (response.isNULL() || response.size() == 0) {
-    boost::shared_ptr<HttpResponse> null_ptr;
-    return null_ptr;
+    return boost::shared_ptr<HttpResponse>();
   }
 
   CharacterVector names = response.names();
@@ -202,7 +201,7 @@ boost::shared_ptr<HttpResponse> listToResponse(
   List responseHeaders = response["headers"];
 
   // Self-frees when response is written
-  boost::shared_ptr<DataSource> pDataSource(nullptr);
+  boost::shared_ptr<DataSource> pDataSource;
 
   // The response can either contain:
   // - bodyFile: String value that names the file that should be streamed
@@ -446,7 +445,7 @@ boost::shared_ptr<HttpResponse> RWebApplication::staticFileResponse(
   // Just fall through, even if the path is one that is in the
   // StaticPathManager.
   if (pRequest->hasHeader("Connection", "Upgrade", true)) {
-    return nullptr;
+    return boost::shared_ptr<HttpResponse>();
   }
 
   // Strip off query string
@@ -459,7 +458,7 @@ boost::shared_ptr<HttpResponse> RWebApplication::staticFileResponse(
   if (!sp_pair) {
     // This was not a static path. Fall through to the R code to handle this
     // path.
-    return nullptr;
+    return boost::shared_ptr<HttpResponse>();
   }
 
   // If we get here, we've matched a static path.
@@ -470,7 +469,7 @@ boost::shared_ptr<HttpResponse> RWebApplication::staticFileResponse(
 
   // This is an excluded path
   if (sp.options.exclude.get()) {
-    return nullptr;
+    return boost::shared_ptr<HttpResponse>();
   }
 
   // Validate headers (if validation pattern was provided).
@@ -498,7 +497,7 @@ boost::shared_ptr<HttpResponse> RWebApplication::staticFileResponse(
       (url_path.length() >= 3 && url_path.substr(url_path.length()-3, 3) == "/..")
   ) {
     if (sp.options.fallthrough.get()) {
-      return nullptr;
+      return boost::shared_ptr<HttpResponse>();
     } else {
       return error_response(pRequest, 400);
     }
@@ -522,7 +521,7 @@ boost::shared_ptr<HttpResponse> RWebApplication::staticFileResponse(
   if (ret != FDS_OK) {
     if (ret == FDS_NOT_EXIST || ret == FDS_ISDIR) {
       if (sp.options.fallthrough.get()) {
-        return nullptr;
+        return boost::shared_ptr<HttpResponse>();
       } else {
         return error_response(pRequest, 404);
       }


### PR DESCRIPTION
This PR has changes to make it compile on RHEL/Centos 6, which doesn't ship with a C++11 compiler.


***** 

Dockerfile for testing:

```Dockerfile
# docker build -t centos6r .

FROM centos:centos6

RUN yum -y install epel-release 
RUN yum -y update 

RUN echo "LANG=en_US.utf8" >> /etc/locale.conf
RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8
RUN export LC_ALL=en_US.UTF-8

RUN yum -y install libtool R-core R-core-devel R-java R-cpp openssl-devel libcurl-devel \
  && echo 'options(repos = c(CRAN = "https://cran.rstudio.com/"), download.file.method = "libcurl")' >> /usr/lib64/R/etc/Rprofile.site

RUN echo "MAKEFLAGS=-j4" >> /usr/lib64/R/etc/Renviron
# Create directories for documentation
RUN mkdir -p /usr/share/doc/R-3.4.3/html
RUN cp /usr/lib64/R/library/stats/html/R.css /usr/share/doc/R-3.4.3/html/

# First install devtools and CRAN version httpuv so that we have dependencies
RUN R -e "install.packages(c('devtools', 'httpuv'))"

CMD bash
```

In the docker container:

```
R
devtools::install_github('rsrtudio/httpuv@fix-centos6')
```

