### PR TITLE
Convert Barrier to shared_ptr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ httpuv 1.5.0.9000
 
 * Fixed issues for compilers that didn't support C++11, notably on RHEL and Centos 6. ([#210](https://github.com/rstudio/httpuv/pull/210))
 
+* Fixed [#208](https://github.com/rstudio/httpuv/issues/208): In some cases, a race condition could cause the R process to exit when starting a new server. ([#211](https://github.com/rstudio/httpuv/pull/211))
+
 httpuv 1.5.0
 ============
 

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -95,7 +95,7 @@ uv_stream_t* createPipeServer(uv_loop_t* pLoop, const std::string& name,
 void createPipeServerSync(uv_loop_t* loop, const std::string& name,
   int mask, boost::shared_ptr<WebApplication> pWebApplication,
   CallbackQueue* background_queue,
-  uv_stream_t** pServer, Barrier* blocker)
+  uv_stream_t** pServer, boost::shared_ptr<Barrier> blocker)
 {
   ASSERT_BACKGROUND_THREAD()
 
@@ -174,7 +174,7 @@ uv_stream_t* createTcpServer(uv_loop_t* pLoop, const std::string& host,
 void createTcpServerSync(uv_loop_t* pLoop, const std::string& host,
   int port, boost::shared_ptr<WebApplication> pWebApplication,
   CallbackQueue* background_queue,
-  uv_stream_t** pServer, Barrier* blocker)
+  uv_stream_t** pServer, boost::shared_ptr<Barrier> blocker)
 {
   ASSERT_BACKGROUND_THREAD()
 

--- a/src/http.h
+++ b/src/http.h
@@ -37,11 +37,11 @@ uv_stream_t* createTcpServer(uv_loop_t* loop, const std::string& host, int port,
 
 void createPipeServerSync(uv_loop_t* loop, const std::string& name, int mask,
   boost::shared_ptr<WebApplication> pWebApplication, CallbackQueue* background_queue,
-  uv_stream_t** pServer, Barrier* blocker);
+  uv_stream_t** pServer, boost::shared_ptr<Barrier> blocker);
 
 void createTcpServerSync(uv_loop_t* loop, const std::string& host, int port,
   boost::shared_ptr<WebApplication> pWebApplication, CallbackQueue* background_queue,
-  uv_stream_t** pServer, Barrier* blocker);
+  uv_stream_t** pServer, boost::shared_ptr<Barrier> blocker);
 
 void freeServer(uv_stream_t* pServer);
 bool runNonBlocking(uv_loop_t* loop);


### PR DESCRIPTION
This fixes #208. The `shared_ptr` ensures that the `Barrier` will not be destroyed while one of the threads is still using it.

Holding off on adding a NEWS to avoid a merge conflict, but this will be the content:

```md
Fixed [#208](https://github.com/rstudio/httpuv/issues/208): In some cases, a race condition could cause the R process to exit when starting a new server. ([#211](https://github.com/rstudio/httpuv/pull/211))

```