### PR TITLE
Consider frame complete when it has no payload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,14 @@ addons:
       - apache2-utils
 
 r:
-- 3.1
-- 3.2
-- oldrel
-- release
-- devel
+  - 3.2
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
+  - devel
+
+
+env:
+  global:
+    - MAKEFLAGS="-j 2"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,8 @@ RoxygenNote: 6.1.1
 Suggests:
     testthat,
     callr,
-    curl
+    curl,
+    websocket
 Collate:
     'RcppExports.R'
     'httpuv.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ httpuv 1.5.1.9000
 
 * In the static file-serving code path, httpuv previously looked for a `Connection: upgrade` header; if it found this header, it would not try to serve a static file, and it woudl instead forward the HTTP request to the R code path. However, some proxies are configured to always set this header, even when the connection is not actually meant to be upgraded. Now, instead of looking for a `Connection: upgrade` header, httpuv looks for the presence of an `Upgrade` header (with any value), and should be more robust to incorrectly-configured proxies. ([#215](https://github.com/rstudio/httpuv/pull/215))
 
+* Fixed handling of messages without payloads: ([#219](https://github.com/rstudio/httpuv/pull/219))
+
 httpuv 1.5.1
 ============
 

--- a/tests/testthat/test-frame-completion.R
+++ b/tests/testthat/test-frame-completion.R
@@ -10,9 +10,9 @@ test_that("a close message with no payload is processed", {
 
   srv <- startServer("127.0.0.1", random_port, list(
     onWSOpen = function(ws) {
-      open_time <- Sys.time()
+      open_time <- as.numeric(Sys.time())
       ws$onClose(function(e) {
-        elapsed <<- Sys.time() - open_time
+        elapsed <<- as.numeric(Sys.time()) - open_time
         stopServer(srv)
       })
     }
@@ -29,11 +29,12 @@ test_that("a close message with no payload is processed", {
     })
   }
 
-  loop_start <- Sys.time()
+  loop_start <- as.numeric(Sys.time())
   while (!later::loop_empty()) {
-    if ((Sys.time() - loop_start) > as.difftime(10, units = "secs")) stop("run loop timed out")
+    loop_elapsed <- as.numeric(Sys.time()) - loop_start
+    if (loop_elapsed > 10) stop("run loop timed out")
     later::run_now()
   }
 
-  testthat::expect_true(elapsed < as.difftime(1, units = "secs"))
+  expect_true(elapsed < 1)
 })

--- a/tests/testthat/test-frame-completion.R
+++ b/tests/testthat/test-frame-completion.R
@@ -3,31 +3,37 @@
 
 context("frame completion")
 
-elapsed <- NULL
+test_that("a close message with no payload is processed", {
+  elapsed <- NULL
 
-random_port <- random_open_port()
+  random_port <- random_open_port()
 
-srv <- startServer("127.0.0.1", random_port, list(
-  onWSOpen = function(ws) {
-    open_time <- Sys.time()
-    ws$onClose(function(e) {
-      elapsed <<- Sys.time() - open_time
-      stopServer(srv)
+  srv <- startServer("127.0.0.1", random_port, list(
+    onWSOpen = function(ws) {
+      open_time <- Sys.time()
+      ws$onClose(function(e) {
+        elapsed <<- Sys.time() - open_time
+        stopServer(srv)
+      })
+    }
+  ))
+
+  on.exit(srv$stop())
+
+  # "Unnecessary" braces here to prevent `later` from attempting to
+  # run callbacks if this test is pasted at the console
+  {
+    ws_client <- websocket::WebSocket$new(sprintf("ws://127.0.0.1:%s", random_port))
+    ws_client$onOpen(function(event) {
+      ws_client$close(NA)
     })
   }
-))
 
-# "Unnecessary" braces here to prevent `later` from attempting to
-# run callbacks if this test is pasted at the console
-{
-  ws_client <- websocket::WebSocket$new(sprintf("ws://127.0.0.1:%s", random_port))
-  ws_client$onOpen(function(event) {
-    ws_client$close(NA)
-  })
-}
+  loop_start <- Sys.time()
+  while (!later::loop_empty()) {
+    if ((Sys.time() - loop_start) > as.difftime(10, units = "secs")) stop("run loop timed out")
+    later::run_now()
+  }
 
-while (!later::loop_empty()) {
-  later::run_now()
-}
-
-testthat::expect_true(elapsed < as.difftime(0.2, units = "secs"))
+  testthat::expect_true(elapsed < as.difftime(1, units = "secs"))
+})

--- a/tests/testthat/test-frame-completion.R
+++ b/tests/testthat/test-frame-completion.R
@@ -25,7 +25,10 @@ test_that("a close message with no payload is processed", {
   {
     ws_client <- websocket::WebSocket$new(sprintf("ws://127.0.0.1:%s", random_port))
     ws_client$onOpen(function(event) {
-      ws_client$close(NA)
+      # NOTE: Depends on websocketpp internals.
+      # 0 below corresponds to close::status::blank, here:
+      # https://github.com/rstudio/websocket/blob/f435899aef3eaecf97af9f3febd87687ecddc3a7/src/lib/websocketpp/close.hpp#L51-L52
+      ws_client$close(0)
     })
   }
 

--- a/tests/testthat/test-frame-completion.R
+++ b/tests/testthat/test-frame-completion.R
@@ -1,0 +1,33 @@
+# Regression test of
+# https://github.com/rstudio/httpuv/pull/219
+
+context("frame completion")
+
+elapsed <- NULL
+
+random_port <- random_open_port()
+
+srv <- startServer("127.0.0.1", random_port, list(
+  onWSOpen = function(ws) {
+    open_time <- Sys.time()
+    ws$onClose(function(e) {
+      elapsed <<- Sys.time() - open_time
+      stopServer(srv)
+    })
+  }
+))
+
+# "Unnecessary" braces here to prevent `later` from attempting to
+# run callbacks if this test is pasted at the console
+{
+  ws_client <- websocket::WebSocket$new(sprintf("ws://127.0.0.1:%s", random_port))
+  ws_client$onOpen(function(event) {
+    ws_client$close(NA)
+  })
+}
+
+while (!later::loop_empty()) {
+  later::run_now()
+}
+
+testthat::expect_true(elapsed < as.difftime(0.2, units = "secs"))


### PR DESCRIPTION
## Background

One day we were recording a session with [shinyloadtest](https://github.com/rstudio/shinyloadtest) and we noticed that closing the browser tab did not immediately terminate the session. In normal operation, when shinyloadtest detects that the browser's websocket has closed (via httpuv WebSocket`ws$onClose()`), it closes the "upstream" (Shiny app) websocket and records a `WS_CLOSE` message in the recording log. Then `record_session()` returns in the R console.

Instead, `record_session()` was behaving like the browser tab had not been closed.

We only observed this problem with Firefox, and only when the target application was RSC (and not e.g. `runExample("01_hello")` locally). When we tried to reproduce with Chrome, `record_session()` returned immediately after tab close, as we expected it to.

Using Firefox, `record_session()` would *eventually* return, about 20 seconds after tab close.

We couldn't expect users to wait that long, and we didn't want to encourage hitting Ctrl-c in the R console because that method introduces other potential difficulties.

## Cause

### Chrome vs Firefox

We compared Chrome and Firefox with Wireshark and determined that both browsers *were* sending WebSocket Close messages.

Closing the tab in Firefox resulted in the 20 second wait, but exiting Firefox completely would cause `$onClose()` to fire.

We concluded that Chrome's WebSocket was closing immediately (at the TCP level) and Firefox was not &mdash; WebSockets in Firefox appear to live for 20 seconds after the tab in which they were created is closed.

### RSC vs local

We noticed that recording a local Shiny app worked, but recording a remote RSC app did not. Comparing traffic with Wireshark, we noticed the Close message sent in the local app case had a reason payload, `1001 - "Going Away"`. The Close message sent in the RSC app case had no payload.

### sock.js

The primary difference between recording a local app and an RSC/SSP app is the presence of [shiny-server-client](https://github.com/rstudio/shiny-server-client) and [sock.js](https://github.com/sockjs/sockjs-client) in the networking stack.

We concluded that the discrepancy in the Close message payload was accounted for by the fact that when sock.js is involved, it calls `close()` on the JS WebSocket, **not** the browser.

The version of sock.js we used registers for the browser's `onunload` event and closes the WebSocket without a close message: https://github.com/sockjs/sockjs-client/blob/0c70698bddcfab826c7b241ed709f69b5b0d41f7/lib/trans-websocket.js#L31

When the browser closes the WebSocket (in the local app case), it does so with the `1001 - "Going Away"` payload.

## Fix

Firefox's behavior (waiting 20 seconds to close the connection at the TCP layer) combined with attempting to record an app involving sock.js exposed a bug in httpuv.

Currently, `onFrameComplete()` is only invoked when a WebSocket message contains a payload, after that payload has been consumed.

With this change, `onFrameComplete()` is also invoked after the header is parsed and there is no payload.

## Testing/QA notes

Joe devised a test (comment on this PR) that checks `ws$onClose()` is called when the client closes and provides no payload. However, the test relies on the websocket package, which is not yet on CRAN.

Once websocket is on CRAN, we should add the test to our suite, and include websocket in the `Suggests` part of our `DESCRIPTION`.