### PR TITLE
Deal gracefully with apps that don't have $call(), also unit tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ httpuv 1.5.1.9001
 
 * Added a new (unexported) function `logLevel()`, for controlling debugging information that will be printed to the console. Previously, httpuv occasionally printed messages like `ERROR: [uv_write] broken pipe` and `ERROR: [uv_write] bad file descriptor` by default. This happened when the server tried to write to a pipe that was already closed, but the situation was not harmful, and was already being handled correctly. Now these messages are printed only if the log level is set to `INFO` or `DEBUG`. ([#223](https://github.com/rstudio/httpuv/pull/223))
 
+* If an application's `$call()` method is missing, it will now give a 404 response instead of a 500 response. ([#237](https://github.com/rstudio/httpuv/pull/237))
+
 * Disallowed backslash in static path, to prevent path traversal attacks. ([#235](https://github.com/rstudio/httpuv/pull/235))
 
 httpuv 1.5.1

--- a/R/httpuv.R
+++ b/R/httpuv.R
@@ -230,7 +230,17 @@ AppWrapper <- R6Class(
       # The cpp_callback is an external pointer to a C++ function that writes
       # the response.
 
-      resp <- rookCall(private$app$call, req, req$.bodyData, seek(req$.bodyData))
+      resp <- if (is.null(private$app$call)) {
+        list(
+          status = 404L,
+          headers = list(
+            "Content-Type" = "text/plain"
+          ),
+          body = "404 Not Found\n"
+        )
+      } else {
+        rookCall(private$app$call, req, req$.bodyData, seek(req$.bodyData))
+      }
       # Note: rookCall() should never throw error because all the work is
       # wrapped in tryCatch().
 

--- a/tests/testthat/test-static-paths.R
+++ b/tests/testthat/test-static-paths.R
@@ -68,6 +68,21 @@ test_that("Basic static file serving", {
   expect_identical(rawToChar(r$content), "404 Not Found\n")
   expect_equal(h$`content-length`, "14")
 
+  # Bad request (400)
+  # jcheng 2019-09-28: I tried to do this same test with /1/../index.html but
+  # it seems like the actual request being made would always end up being
+  # /1/index.html instead, which would succeed.
+  r <- fetch(local_url("/1/..%2Findex.html", s$getPort()))
+  h <- parse_headers_list(r$headers)
+  expect_equal(r$status_code, 400)
+  expect_identical(rawToChar(r$content), "400 Bad Request\n")
+
+  # Missing file (404)
+  r <- fetch(local_url("/1/..\\index.html", s$getPort()))
+  h <- parse_headers_list(r$headers)
+  expect_equal(r$status_code, 404)
+  expect_identical(rawToChar(r$content), "404 Not Found\n")
+
   # Missing directory in path (404)
   r <- fetch(local_url("/foo/bar", s$getPort()))
   h <- parse_headers_list(r$headers)


### PR DESCRIPTION
(Might want to wait until post-1.5.2 for this one.)

If you have an app without a `call()` but with static paths, then any requests that don't match the static paths end up giving an error 500 with something about not being able to find `func`. This PR causes a graceful 404 to be returned in this situation instead.

Also contains unit tests for path traversal attack mitigation (which is how I discovered this in the first place).