### PR TITLE
Static file serving fails on Windows with concurrent requests on the same file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@ httpuv 1.5.1.9001
 
 * Disallowed backslash in static path, to prevent path traversal attacks. ([#235](https://github.com/rstudio/httpuv/pull/235))
 
+* Static file serving on Windows could fail if multiple requests accessed the same file simultaneously. ([#239](https://github.com/rstudio/httpuv/pull/239))
+
 httpuv 1.5.1
 ============
 

--- a/src/filedatasource-win.cpp
+++ b/src/filedatasource-win.cpp
@@ -20,7 +20,7 @@ FileDataSourceResult FileDataSource::initialize(const std::string& path, bool ow
 
   _hFile = CreateFileW(utf8ToWide(path).data(),
                       GENERIC_READ,
-                      0, // exclusive access
+                      FILE_SHARE_READ, // allow other processes to read
                       NULL, // security attributes
                       OPEN_EXISTING,
                       flags,


### PR DESCRIPTION
Fixes #238. See that issue for testing notes.

FileDataSource shouldn't lock files for exclusive access while
sending results.