### PR TITLE
Avoids creating a new ErrorStream instance for each request

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+httpuv 1.5.2.9000
+=================
+
+* Avoid creating a new Rook error stream object for each request. This should improve performance. ([#245](https://github.com/rstudio/httpuv/pull/245))
+
 httpuv 1.5.2
 ============
 

--- a/R/httpuv.R
+++ b/R/httpuv.R
@@ -88,6 +88,7 @@ ErrorStream <- R6Class(
   ),
   cloneable = FALSE
 )
+stdErrStream <- ErrorStream$new()
 
 #' @importFrom promises promise then finally is.promise %...>% %...!%
 rookCall <- function(func, req, data = NULL, dataLength = -1) {
@@ -102,7 +103,7 @@ rookCall <- function(func, req, data = NULL, dataLength = -1) {
 
     req$rook.input <- inputStream
 
-    req$rook.errors <- ErrorStream$new()
+    req$rook.errors <- stdErrStream
 
     req$httpuv.version <- httpuv_version()
 


### PR DESCRIPTION
My apologies if I've misinterpreted something here, I don't really know how to "test" Rook-related functionality.

The [Rook specification for the Error Stream](https://github.com/jeffreyhorner/Rook/blob/a5e45f751/README.md#the-error-stream) seems to indicate only that it must have `cat()` and `flush()` methods. I noticed that the current R6 class implementation has no internal state to mutate, and yet a new instance is created for each request. This struck me as avoidable.

This PR simply creates a single instance that can be reused by all requests. The change should improve performance; my "hello, world" example is showing a 20% increase in throughput.

~~I did not add a note to the `NEWS.md` file, but my suggestion would be~~

~~> Avoid creating a new Rook error stream object for each request.~~