### PR TITLE
Remove dependency that the environment varialbe $FRAMEWORK not be set

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ httpuv 1.5.2.9000
 
 * Resolved [#247](https://github.com/rstudio/httpuv/issues/247): httpuv no longer returns a HTTP 400 code for static files when the "Content-Length" header is 0. This Content-Length header is inserted by some proxies even for messages without payloads. ([#248](https://github.com/rstudio/httpuv/pull/248))
 
+* Resolved [#253](https://github.com/rstudio/httpuv/issues/253): Setting the FRAMEWORK environment variable would break compilation.  This change removes any dependency on that variable. ([#254](https://github.com/rstudio/httpuv/pull/254))
+
 httpuv 1.5.2
 ============
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -5,11 +5,12 @@ CXX_STD=CXX11
 
 UNAME := $(shell uname)
 
+PKG_LIBS = ./libuv/.libs/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o -pthread
+
 ifeq ($(UNAME), Darwin)
-FRAMEWORK = -framework CoreServices
+PKG_LIBS += -framework CoreServices
 endif
 
-PKG_LIBS = ./libuv/.libs/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o $(FRAMEWORK) -pthread
 ifeq ($(UNAME), SunOS)
 PKG_LIBS += -lkstat -lsendfile -lsocket -lxnet
 endif


### PR DESCRIPTION
This change fixes https://github.com/rstudio/httpuv/issues/253

Currently, if the environment where httpuv is being installed from
has the environment variable $FRAMEWORK set to any value, then that
value will get inadvertently passed to the compilation script causing
it to fail with the error:
g++: error: $FRAMEWORK: No such file or directory

This change removes any reference to that environment variable