### PR TITLE
Skip filename encoding tests on non-UTF-8 Unix platforms

### DIFF
--- a/tests/testthat/test-static-paths.R
+++ b/tests/testthat/test-static-paths.R
@@ -765,6 +765,13 @@ test_that("Last-Modified and If-Modified-Since headers", {
 
 
 test_that("Paths with non-ASCII characters", {
+  # Workaround for https://github.com/rstudio/httpuv/issues/264
+  # On Unix platforms that are using a non-UTF-8 locale, don't do these tests.
+  testthat::skip_if(
+    .Platform$OS.type == "unix" && Encoding(enc2native("\U00FC")) != "UTF-8",
+    "Skipping non-ASCII path tests on UTF-8 Unix system"
+  )
+
   # "apps/fü", in UTF-8 encoding.
   nonascii_path <- test_path("apps/f\U00FC")
   dir.create(nonascii_path)


### PR DESCRIPTION
Resolves #264.

To verify:

```
docker run --security-opt seccomp=unconfined --rm -ti rocker/r-devel /bin/bash

apt install -y git libssl-dev vim nano

echo en_US ISO-8859-1 >> /etc/locale.gen
locale-gen

echo MAKEFLAGS=-j4 > ~/.Renviron

git clone https://github.com/rstudio/httpuv.git
RD -e "install.packages('remotes')"
RD -e 'remotes::install_deps("httpuv", dependencies = TRUE)'

export LANG=en_US.iso88591
# This prints a warning, but it seems to be necessary for things to work.
export LC_ALL=en_US.iso88591

RD --quiet -e 'Sys.getlocale()'

# Get the right branch
cd httpuv
git checkout  wch-filename-encoding
cd ..

RD CMD build httpuv
R CMD check httpuv_1.5.2.9000.tar.gz 
```

This will pass, but if you check out the master branch, it will fail.