### PR TITLE
Ensure memcpy copies from 64 bit block

### DIFF
--- a/src/websockets-base.cpp
+++ b/src/websockets-base.cpp
@@ -30,25 +30,27 @@ void WebSocketProto::createFrameHeader(
 
   unsigned char* pBuf = (unsigned char*)pData;
   unsigned char* pMaskingKey = pBuf + 2;
+  // Need to copy from a 64-bit chunk of memory, but size_t may be smaller.
+  uint64_t payloadSize_64 = payloadSize;
 
   pBuf[0] =
     toFin(true) << 7 | // FIN; always true
     encodeOpcode(opcode);
   pBuf[1] = mask ? 1 << 7 : 0;
-  if (payloadSize <= 125) {
-    pBuf[1] |= payloadSize;
+  if (payloadSize_64 <= 125) {
+    pBuf[1] |= payloadSize_64;
     pMaskingKey = pBuf + 2;
   }
-  else if (payloadSize <= 65535) {// 2^16-1
+  else if (payloadSize_64 <= 65535) {// 2^16-1
     pBuf[1] |= 126;
-    memcpy(pBuf + 2, &payloadSize, sizeof(uint16_t));
+    memcpy(pBuf + 2, &payloadSize_64, sizeof(uint16_t));
     if (!isBigEndian())
       swapByteOrder(pBuf + 2, pBuf + 4);
     pMaskingKey = pBuf + 4;
   }
   else {
     pBuf[1] |= 127;
-    memcpy(pBuf + 2, &payloadSize, sizeof(uint64_t));
+    memcpy(pBuf + 2, &payloadSize_64, sizeof(uint64_t));
     if (!isBigEndian())
       swapByteOrder(pBuf + 2, pBuf + 10);
     pMaskingKey = pBuf + 10;


### PR DESCRIPTION
Fixes the following warning on Windows (presumably 32-bit):

```
Found the following significant warnings:
  websockets-base.cpp:51:11: warning: 'void* memcpy(void*, const void*, size_t)' forming offset [5, 8] is out of the bounds [0, 4] of object 'payloadSize' with type 'size_t' {aka 'unsigned int'} [-Warray-bounds]
```