### PR TITLE
Fix build on Solaris

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 httpuv 1.5.3.9000
 ==============
 
+* Fix build for Solaris. (#271)
+
 httpuv 1.5.3.1
 ==============
 

--- a/src/libuv/Makefile.in
+++ b/src/libuv/Makefile.in
@@ -340,6 +340,7 @@ check_PROGRAMS = test/run-tests$(EXEEXT)
 @SUNOS_TRUE@am__append_55 = include/uv/sunos.h
 @SUNOS_TRUE@am__append_56 = -D__EXTENSIONS__ \
 @SUNOS_TRUE@                   -D_XOPEN_SOURCE=500 \
+@SUNOS_TRUE@                   -DSUNOS_NO_IFADDRS \
 @SUNOS_TRUE@                   -D_REENTRANT
 
 @SUNOS_TRUE@am__append_57 = src/unix/no-proctitle.c \


### PR DESCRIPTION
In the most recent libuv update, I forgot to run `autogen.sh`. I ran it here, then followed the rest of the directions from src/README.md. There was only one file that changed, Makefile.in.

I've tested this change on a Solaris VM, and it fixes a build problem on that platform which was reported to us by CRAN.