### PR TITLE
Fix logic for non-ASCII filename test

### DIFF
--- a/tests/testthat/test-static-paths.R
+++ b/tests/testthat/test-static-paths.R
@@ -768,7 +768,7 @@ test_that("Paths with non-ASCII characters", {
   # Workaround for https://github.com/rstudio/httpuv/issues/264
   # On Unix platforms that are using a non-UTF-8 locale, don't do these tests.
   testthat::skip_if(
-    .Platform$OS.type == "unix" && isTRUE(l10n_info()[["UTF-8"]]),
+    .Platform$OS.type == "unix" && !l10n_info()[["UTF-8"]],
     "Skipping non-ASCII path tests on UTF-8 Unix system"
   )
 


### PR DESCRIPTION
I tested in a Docker container using the commands listed in #265 (with slight modifications), and this fixes the issue.