### PR TITLE
Fix header parsing for values that span more than one call to _on_header_value

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: httpuv
 Type: Package
 Encoding: UTF-8
 Title: HTTP and WebSocket Server Library
-Version: 1.5.3.9000
+Version: 1.5.3.9001
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut"), email = "joe@rstudio.com"),
     person("Winston", "Chang", role = c("aut", "cre"), email = "winston@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 httpuv 1.5.3.9000
 ==============
 
+* Fixed #275: Large HTTP request headers could get truncated if they spanned
+  more than one TCP message. (#277)
+
 * Fixed build for Solaris. (#271)
 
 * Fixed a test that had incorrect logic. (#272)

--- a/src/httprequest.cpp
+++ b/src/httprequest.cpp
@@ -138,8 +138,7 @@ void HttpRequest::_newRequest() {
   _handling_request = true;
   _headers.clear();
   _response_scheduled = false;
-
-  _last_header_state = "start";
+  _last_header_state = START;
 
   // Schedule on main thread:
   //   this->_initializeEnv();
@@ -227,8 +226,8 @@ int HttpRequest::_on_header_field(http_parser* pParser, const char* pAt, size_t 
   ASSERT_BACKGROUND_THREAD()
   debug_log("HttpRequest::_on_header_field", LOG_DEBUG);
 
-  if (_last_header_state != "field") {
-    _last_header_state = "field";
+  if (_last_header_state != FIELD) {
+    _last_header_state = FIELD;
     _lastHeaderField.clear();
   }
 
@@ -242,8 +241,8 @@ int HttpRequest::_on_header_value(http_parser* pParser, const char* pAt, size_t 
 
   std::string value(pAt, length);
 
-  if (_last_header_state != "value") {
-    _last_header_state = "value";
+  if (_last_header_state != VALUE) {
+    _last_header_state = VALUE;
 
     if (_headers.find(_lastHeaderField) != _headers.end()) {
       // If the field already exists. This can happen if there are multiple

--- a/src/httprequest.cpp
+++ b/src/httprequest.cpp
@@ -139,6 +139,8 @@ void HttpRequest::_newRequest() {
   _headers.clear();
   _response_scheduled = false;
 
+  _last_header_state = "start";
+
   // Schedule on main thread:
   //   this->_initializeEnv();
   invoke_later(
@@ -224,6 +226,12 @@ int HttpRequest::_on_status(http_parser* pParser, const char* pAt, size_t length
 int HttpRequest::_on_header_field(http_parser* pParser, const char* pAt, size_t length) {
   ASSERT_BACKGROUND_THREAD()
   debug_log("HttpRequest::_on_header_field", LOG_DEBUG);
+
+  if (_last_header_state != "field") {
+    _last_header_state = "field";
+    _lastHeaderField.clear();
+  }
+
   std::copy(pAt, pAt + length, std::back_inserter(_lastHeaderField));
   return 0;
 }
@@ -234,24 +242,40 @@ int HttpRequest::_on_header_value(http_parser* pParser, const char* pAt, size_t 
 
   std::string value(pAt, length);
 
-  if (_headers.find(_lastHeaderField) != _headers.end()) {
-    // If the field already exists...
+  if (_last_header_state != "value") {
+    _last_header_state = "value";
 
-    if (_headers[_lastHeaderField].size() > 0) {
-      // ...and is already non-empty...
+    if (_headers.find(_lastHeaderField) != _headers.end()) {
+      // If the field already exists. This can happen if there are multiple
+      // headers with the same name, as in:
+      //   foo: 1
+      //   foo: 2
 
-      if (value.size() > 0) {
-        // ...and this value is also non-empty, then combine using comma...
-        value = _headers[_lastHeaderField] + "," + value;
-      } else {
-        // ...but if this value is empty, then use previous value (no-op).
-        value = _headers[_lastHeaderField];
+      if (_headers[_lastHeaderField].size() > 0) {
+        // ...and is already non-empty...
+
+        if (value.size() > 0) {
+          // ...and this value is also non-empty, then combine using comma...
+          value = _headers[_lastHeaderField] + "," + value;
+        } else {
+          // ...but if this value is empty, then use previous value (no-op).
+          value = _headers[_lastHeaderField];
+        }
       }
     }
+
+    _headers[_lastHeaderField] = value;
+
+  } else {
+    // This is a subsequent call to this function when the http parser receives
+    // another chunk of data for the same field. This can happen when there are
+    // very large headers, as in:
+    //   foo: 1234............5678
+    // where the "...." is so long that it gets split across TCP messages.
+
+    _headers[_lastHeaderField].append(value);
   }
 
-  _headers[_lastHeaderField] = value;
-  _lastHeaderField.clear();
   return 0;
 }
 

--- a/src/httprequest.h
+++ b/src/httprequest.h
@@ -82,7 +82,17 @@ private:
   // to schedule callbacks to run on the background thread.
   CallbackQueue* _background_queue;
 
-  std::string _last_header_state;
+  // Used to keep track of state when parsing headers. This is needed because
+  // sometimes the header fields and values can be split across multiple TCP
+  // messages, resulting in multiple calls to _on_header_field or
+  // _on_header_value.
+  enum LastHeaderState
+  {
+    START,
+    FIELD,
+    VALUE
+  };
+  LastHeaderState _last_header_state;
 
 public:
   HttpRequest(uv_loop_t* pLoop,
@@ -110,7 +120,7 @@ public:
     // This is used by the macro-defined callbacks like _on_message_begin
     _parser.data = this;
 
-    _last_header_state = "start";
+    _last_header_state = START;
   }
 
   virtual ~HttpRequest() {

--- a/src/httprequest.h
+++ b/src/httprequest.h
@@ -82,6 +82,8 @@ private:
   // to schedule callbacks to run on the background thread.
   CallbackQueue* _background_queue;
 
+  std::string _last_header_state;
+
 public:
   HttpRequest(uv_loop_t* pLoop,
               boost::shared_ptr<WebApplication> pWebApplication,
@@ -107,6 +109,8 @@ public:
     http_parser_init(&_parser, HTTP_REQUEST);
     // This is used by the macro-defined callbacks like _on_message_begin
     _parser.data = this;
+
+    _last_header_state = "start";
   }
 
   virtual ~HttpRequest() {

--- a/tests/testthat/test-http-parse.R
+++ b/tests/testthat/test-http-parse.R
@@ -1,0 +1,98 @@
+context("http-parse")
+
+test_that("Large HTTP header values are preserved", {
+  # This is a test for https://github.com/rstudio/httpuv/issues/275
+  # When there is a very large header, it may span multiple TCP messages.
+  # Previously, these headers would get truncated.
+  s <- httpuv::startServer("0.0.0.0", randomPort(),
+    list(
+      call = function(req) {
+        list(
+          status = 200L,
+          headers = list('Content-Type' = 'text/plain'),
+          # Use paste0("", ...) in case the header is NULL
+          body = paste0("", req$HTTP_TEST_HEADER)
+        )
+      }
+    )
+  )
+  on.exit(s$stop())
+
+  # Create a request with a large header (80000 bytes)
+  # The maximum size of a TCP message is 64kB, so I believe this header will
+  # necessarily result in more than 1 call to HttpRequest::_on_header_value().
+  # Note that this is under the HTTP_MAX_HEADER_SIZE defined in http_parser.h
+  # to be 80*1024. A larger message would result in the server just closing the
+  # connection.
+  long_string <- paste0(rep(".", 80000), collapse = "")
+  h <- new_handle()
+  handle_setheaders(h, `test-header` = long_string)
+
+  res <- fetch(local_url("/", s$getPort()),  h)
+  content <- rawToChar(res$content)
+  expect_identical(content, long_string)
+
+
+  # Similar to previous, but make sure there are two header entries with the
+  # same field name, as in:
+  #   foo: aaaaaaaa....
+  #   foo: bbbbbbbb....
+  # The resulting value of foo should should be "aaaaaa,bbbbbbbbbbbb"
+  # (Note: I've tested, and repeating the same header name with curl does result
+  # two of those headers.)
+  long_string_a <- paste0(rep("a", 100), collapse = "")
+  long_string_b <- paste0(rep("b", 80000), collapse = "")
+
+  # The second test-header value is the long one, so it will be split across
+  # multiple TCP messages.
+  h <- new_handle()
+  handle_setheaders(h, `test-header` = long_string_a, `test-header` = long_string_b)
+  res <- fetch(local_url("/", s$getPort()),  h)
+  content <- rawToChar(res$content)
+  expect_identical(content, paste0(long_string_a, ",", long_string_b))
+
+  # The first test-header value is the long one, so it will be split across
+  # multiple TCP messages.
+  h <- new_handle()
+  handle_setheaders(h, `test-header` = long_string_b, `test-header` = long_string_a)
+  res <- fetch(local_url("/", s$getPort()),  h)
+  content <- rawToChar(res$content)
+  expect_identical(content, paste0(long_string_b, ",", long_string_a))
+})
+
+
+test_that("Large HTTP header field names are preserved", {
+  # Also for https://github.com/rstudio/httpuv/issues/275
+  # This tests for field names that are split across messages.
+  headers_received <- NULL
+  s <- httpuv::startServer("0.0.0.0", randomPort(),
+    list(
+      call = function(req) {
+        # Save the headers for examination later
+        headers_received <<- req$HEADERS
+        list(
+          status = 200L,
+          headers = list('Content-Type' = 'text/plain'),
+          body = paste0("OK")
+        )
+      }
+    )
+  )
+  on.exit(s$stop())
+  # Test for long field names, as in:
+  #  aaaaaa...aaaaaa: A
+  #  bbbbbb...bbbbbb: B
+  # Variable names in R must be 10000 bytes or less, so we need several of them
+  # to do this test.
+  h <- new_handle()
+  values <- as.list(LETTERS[1:8])
+  # Use 9900-byte field names (instead of 10000) because the Rook object makes
+  # them longer by prepending "HTTP_".
+  fields <- vapply(letters[1:8], function(x) paste0(rep(x, 9900), collapse = ""), "")
+  headers <- setNames(values, fields)
+  do.call(handle_setheaders, c(list(h), headers))
+
+  res <- fetch(local_url("/", s$getPort()),  h)
+  expect_true(all(fields %in% names(headers_received)))
+  expect_identical(as.list(headers_received[fields]), headers)
+})


### PR DESCRIPTION
This fixes #275.

cc @aronatkins