### PR TITLE
Fix sha1 calculation on big-endian systems.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 httpuv 1.5.4.9000
 =================
 
+* Fix SHA1 calculation, and thus WebSocket server handshakes, on big-endian systems.
 
 httpuv 1.5.4
 ============

--- a/src/sha1/sha1.c
+++ b/src/sha1/sha1.c
@@ -86,6 +86,9 @@ A million repetitions of "a"
 #include <string.h>
 #include <stdint.h>
 
+/* To get WORDS_BIGENDIAN definition. */
+#include <Rconfig.h>
+
 #include "sha1.h"
 
 void SHA1_Transform(uint32_t state[5], const uint8_t buffer[64]);


### PR DESCRIPTION
Even though there is a check for `WORDS_BIGENDIAN`, this does nothing because that is `#define`d by R headers, which are not included by this code. But instead of fixing the `#define`, it is simpler to load the `block` workspace from the `buffer` as big-endian `uint32_t` directly.

This does not appear exercised by tests, because nothing appears to read `Sec-WebSocket-Accept` anywhere that I can tell. However, if you run the latest version `websocket`'s tests (which use `httpuv` as a server), then they fail on big-endian machines because `websocket` _does_ calculate the sha1 correctly and verify `Sec-WebSocket-Accept`.