### PR TITLE
Allow responses to omit a body and Content-Length header

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ httpuv 1.5.4.9000
 
 * Previously, responses required `headers` to be a named list. Now it can also be `NULL`, an empty unnamed list, or it can be unset. (#289)
 
+* Allow responses to omit `body` (or set it as `NULL`) to avoid sending a body or setting the `Content-Length` header. This is intended for use with HTTP 204/304 responses. (#288)
+
 httpuv 1.5.4
 ============
 

--- a/R/httpuv.R
+++ b/R/httpuv.R
@@ -484,10 +484,12 @@ WebSocket <- R6Class(
 #'
 #'   \describe{
 #'     \item{\code{call(req)}}{Process the given HTTP request, and return an
-#'     HTTP response. This method should be implemented in accordance with the
+#'     HTTP response (see Response Values). This method should be implemented in
+#'     accordance with the
 #'     \href{https://github.com/jeffreyhorner/Rook/blob/a5e45f751/README.md}{Rook}
-#'     specification.} Note that httpuv augments \code{req} with an additional item,
-#'     \code{req$HEADERS}, which is a named character vector of request headers.
+#'     specification. Note that httpuv augments \code{req} with an additional
+#'     item, \code{req$HEADERS}, which is a named character vector of request
+#'     headers.}
 #'     \item{\code{onHeaders(req)}}{Optional. Similar to \code{call}, but occurs
 #'     when headers are received. Return \code{NULL} to continue normal
 #'     processing of the request, or a Rook response to send that response,
@@ -512,6 +514,26 @@ WebSocket <- R6Class(
 #'   The \code{startPipeServer} variant can be used instead of
 #'   \code{startServer} to listen on a Unix domain socket or named pipe rather
 #'   than a TCP socket (this is not common).
+#'
+#' @section Response Values:
+#'
+#' The \code{call} function is expected to return a list containing the
+#' following, which are converted to an HTTP response and sent to the client:
+#'
+#' \describe{
+#'   \item{\code{status}}{A numeric HTTP status code, e.g. \code{200} or
+#'     \code{404L}.}
+#'
+#'   \item{\code{headers}}{A named list of HTTP headers and their values, as
+#'     strings. This can also be missing, an empty list, or `NULL`, in which
+#'     case no headers (other than the \code{Date} and \code{Content-Length}
+#'     headers, as required) will be added.}
+#'
+#'   \item{\code{body}}{A string (or \code{raw} vector) to be sent as the body
+#'     of the HTTP response. This can also be omitted or set to \code{NULL} to
+#'     avoid sending any body, which is useful for HTTP \code{1xx}, \code{204},
+#'     and \code{304} responses, as well as responses to \code{HEAD} requests.}
+#' }
 #'
 #' @return A \code{\link{WebServer}} or \code{\link{PipeServer}} object.
 #'

--- a/man/startServer.Rd
+++ b/man/startServer.Rd
@@ -77,10 +77,12 @@ contains the following methods and fields:
 
 \describe{
 \item{\code{call(req)}}{Process the given HTTP request, and return an
-HTTP response. This method should be implemented in accordance with the
+HTTP response (see Response Values). This method should be implemented in
+accordance with the
 \href{https://github.com/jeffreyhorner/Rook/blob/a5e45f751/README.md}{Rook}
-specification.} Note that httpuv augments \code{req} with an additional item,
-\code{req$HEADERS}, which is a named character vector of request headers.
+specification. Note that httpuv augments \code{req} with an additional
+item, \code{req$HEADERS}, which is a named character vector of request
+headers.}
 \item{\code{onHeaders(req)}}{Optional. Similar to \code{call}, but occurs
 when headers are received. Return \code{NULL} to continue normal
 processing of the request, or a Rook response to send that response,
@@ -106,6 +108,28 @@ The \code{startPipeServer} variant can be used instead of
 \code{startServer} to listen on a Unix domain socket or named pipe rather
 than a TCP socket (this is not common).
 }
+\section{Response Values}{
+
+
+The \code{call} function is expected to return a list containing the
+following, which are converted to an HTTP response and sent to the client:
+
+\describe{
+\item{\code{status}}{A numeric HTTP status code, e.g. \code{200} or
+\code{404L}.}
+
+\item{\code{headers}}{A named list of HTTP headers and their values, as
+strings. This can also be missing, an empty list, or \code{NULL}, in which
+case no headers (other than the \code{Date} and \code{Content-Length}
+headers, as required) will be added.}
+
+\item{\code{body}}{A string (or \code{raw} vector) to be sent as the body
+of the HTTP response. This can also be omitted or set to \code{NULL} to
+avoid sending any body, which is useful for HTTP \code{1xx}, \code{204},
+and \code{304} responses, as well as responses to \code{HEAD} requests.}
+}
+}
+
 \examples{
 \dontrun{
 # A very basic application

--- a/src/httpresponse.cpp
+++ b/src/httpresponse.cpp
@@ -73,7 +73,11 @@ void HttpResponse::writeResponse() {
     }
   }
 
-  if (_pBody && !hasContentLengthHeader) {
+  // Some valid responses (such as HTTP 204 and 304) must not set this header,
+  // since they can't have a body.
+  //
+  // See: https://tools.ietf.org/html/rfc7230#section-3.3.2
+  if (_pBody != nullptr && !hasContentLengthHeader) {
     response << "Content-Length: " << _pBody->size() << "\r\n";
   }
 

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -86,3 +86,55 @@ test_that("Empty and NULL headers are OK", {
   expect_equal(r$status_code, 200)
   expect_identical(r$content, raw())
 })
+
+
+test_that("Content length depends on the presence of 'body'", {
+  s <- startServer("127.0.0.1", randomPort(),
+    list(
+      call = function(req) {
+        if (req$PATH_INFO == "/ok") {
+          list(
+            status = 200L,
+            headers = list('Content-Type' = 'text/html'),
+            body = if (req$REQUEST_METHOD != "HEAD") raw()
+          )
+        } else if (req$PATH_INFO == "/nullbody") {
+          list(
+            status = 204L,
+            headers = list('Content-Type' = 'text/html'),
+            body = NULL
+          )
+        } else if (req$PATH_INFO == "/nobody") {
+          list(
+            status = 204L,
+            headers = list('Content-Type' = 'text/html')
+          )
+        }
+      }
+    )
+  )
+  on.exit(s$stop())
+  expect_equal(length(listServers()), 1)
+
+  r1 <- fetch(local_url("/ok", s$getPort()))
+  # HEAD requests should not have a body.
+  r2 <- fetch(local_url("/ok", s$getPort()), new_handle(nobody = TRUE))
+  r3 <- fetch(local_url("/nullbody", s$getPort()))
+  r4 <- fetch(local_url("/nobody", s$getPort()))
+
+  expect_equal(r1$status_code, 200)
+  expect_equal(r2$status_code, 200)
+  expect_equal(r3$status_code, 204)
+  expect_equal(r3$status_code, 204)
+
+  expect_equal(length(r1$content), 0)
+  expect_equal(length(r2$content), 0)
+  expect_equal(length(r3$content), 0)
+  expect_equal(length(r4$content), 0)
+
+  expect_identical(parse_headers_list(r1$headers)$`content-length`, "0")
+  # HEAD requests *can* have a content-length, but they don't have to.
+  expect_identical(parse_headers_list(r2$headers)$`content-length`, NULL)
+  expect_identical(parse_headers_list(r3$headers)$`content-length`, NULL)
+  expect_identical(parse_headers_list(r4$headers)$`content-length`, NULL)
+})


### PR DESCRIPTION
The current behaviour of **httpuv** is to automatically set a `Content-Length` header computed from the length of the body. This results in incorrect HTTP 204, 304, and 1xx responses.

RFC 7230 (part of the HTTP 1.1 specification) [says the following](https://tools.ietf.org/html/rfc7230#section-3.3.2) about the Content-Length header:

> A server MAY send a Content-Length header field in a 304 (Not
> Modified) response to a conditional GET request (Section 4.1 of
> [RFC7232]); a server MUST NOT send Content-Length in such a response
> unless its field-value equals the decimal number of octets that would
> have been sent in the payload body of a 200 (OK) response to the same
> request.
>
> A server MUST NOT send a Content-Length header field in any response
> with a status code of 1xx (Informational) or 204 (No Content).

Moreover, HTTP 204 and 304 responses should actually send no body at all. RFC 7231 [states](https://tools.ietf.org/html/rfc7231#section-6.3.5):

> A 204 response is terminated by the first empty line after the header
> fields because it cannot contain a message body.

and RFC 7232 [says]():

> A 304 response cannot contain a message-body; it is always terminated
> by the first empty line after the header fields.

~This PR proposes changes to the handling of HTTP 204 and 304 responses to bring them in line with the spec. I haven't touched HTTP 1xx responses because they're mostly irrelevant and some old Websocket implementations actually do, weirdly, use a `Content-Length`.~

~The implementation is actually really simple: we now ignores any body if a Rook response includes 204 or 304 as the
status, leaving the `DataSource` pointer as `NULL`. This ensures (1) that we don't send a body, and as a side effect (2) that we don't set a `Content-Length` header. I added a comment to the Content-Length header code explaining this edge case, as well, even though there are no code changes there.~

Edit: As per discussion, this behaviour is now optional, triggered by excluding (or setting as `NULL`) the `body` in a Rook response.

It's still possible for users to add a `Content-Length` header directly, which they might want to do, e.g. to fulfill the HTTP 304 behaviour quoted above.