### PR TITLE
Allow headers to be NULL or an unnamed list

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ httpuv 1.5.4.9000
 
 * Fix SHA1 calculation, and thus WebSocket server handshakes, on big-endian systems. (#284)
 
+* Previously, responses required `headers` to be a named list. Now it can also be `NULL`, an empty unnamed list, or it can be unset. (#289)
+
 httpuv 1.5.4
 ============
 

--- a/R/httpuv.R
+++ b/R/httpuv.R
@@ -121,6 +121,14 @@ rookCall <- function(func, req, data = NULL, dataLength = -1) {
     if (is.null(resp) || length(resp) == 0)
       return(NULL)
 
+    # If headers is an empty unnamed list, convert to named list so that
+    # the C++ code won't error.
+    if (is.null(resp$headers) ||
+        (length(resp$headers) == 0 && is.null(names(resp$headers))))
+    {
+      resp$headers <- named_list()
+    }
+
     # Coerce all headers to character
     resp$headers <- lapply(resp$headers, paste)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -64,3 +64,8 @@ logLevel <- function(level = NULL) {
   }
 
 }
+
+# Create an empty named list
+named_list <- function() {
+  list(a = 1)[0]
+}

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -44,3 +44,45 @@ test_that("Basic functionality", {
   stopAllServers()
   expect_equal(length(listServers()), 0)
 })
+
+
+test_that("Empty and NULL headers are OK", {
+  s <- startServer("127.0.0.1", randomPort(),
+    list(
+      call = function(req) {
+        if (req$PATH_INFO == "/null") {
+          list(
+            status = 200L,
+            headers = NULL,
+            body = ""
+          )
+        } else if (req$PATH_INFO == "/emptylist") {
+          list(
+            status = 200L,
+            headers = list(),
+            body = ""
+          )
+        } else if (req$PATH_INFO == "/noheaders") {
+          list(
+            status = 200L,
+            body = ""
+          )
+        }
+      }
+    )
+  )
+  on.exit(s$stop())
+  expect_equal(length(listServers()), 1)
+
+  r <- fetch(local_url("/null", s$getPort()))
+  expect_equal(r$status_code, 200)
+  expect_identical(r$content, raw())
+
+  r <- fetch(local_url("/emptylist", s$getPort()))
+  expect_equal(r$status_code, 200)
+  expect_identical(r$content, raw())
+
+  r <- fetch(local_url("/noheaders", s$getPort()))
+  expect_equal(r$status_code, 200)
+  expect_identical(r$content, raw())
+})


### PR DESCRIPTION
Previously, `headers` had to be a named list. In order to have no headers (besides the ones httpuv adds automatically), `headers` would have to be an empty _named_ list, which is a little awkward to create. With this change, `headers` can be `NULL`, `list()` (an empty unnamed list), or it can be unset.

For example, this app would not work before, but it does now:

```R
s <- startServer("127.0.0.1", 5000,
  list(
    call = function(req) {
      list(
        status = 200L,
        headers = list(),
        body = ""
      )
    }
  )
)
```

The result:

```
$ curl -i http://localhost:5000
HTTP/1.1 200 OK
Date: Thu, 26 Nov 2020 16:33:55 GMT
Content-Length: 0

```