### PR TITLE
Add partial support for the 'Range' header when serving static files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ httpuv 1.5.4.9000
 
 * Allow responses to omit `body` (or set it as `NULL`) to avoid sending a body or setting the `Content-Length` header. This is intended for use with HTTP 204/304 responses. (#288)
 
+* Resolved #259: Static files now support common range requests. (#290)
+
 httpuv 1.5.4
 ============
 

--- a/src/filedatasource.h
+++ b/src/filedatasource.h
@@ -16,10 +16,12 @@ enum FileDataSourceResult {
 class FileDataSource : public DataSource {
 #ifdef _WIN32
   HANDLE _hFile;
-  LARGE_INTEGER _length;
+  uint64_t _payloadSize;
+  LARGE_INTEGER _fsize;
 #else
   int _fd;
-  off_t _length;
+  off_t _payloadSize;
+  off_t _fsize;
 #endif
   std::string _lastErrorMessage;
 
@@ -31,7 +33,12 @@ public:
   }
 
   FileDataSourceResult initialize(const std::string& path, bool owned);
+  // Total size of the data in this source, in bytes, after accounting for file
+  // size and range settings.
   uint64_t size() const;
+  // Total size of the underlying file in this source, in bytes.
+  uint64_t fileSize() const;
+  bool setRange(uint64_t start, uint64_t end);
   uv_buf_t getData(size_t bytesDesired);
   void freeData(uv_buf_t buffer);
   // Get the mtime of the file. If there's an error, return 0.


### PR DESCRIPTION
As proposed in #259. I haven't done extensive 'real-world' testing, but I've been able to use this to enable rewinding/skipping in HTML `<audio>` tags in a Shiny app.

This PR includes

* Parsing and validation of the [most common forms](https://tools.ietf.org/html/rfc7233#section-3.1) of the `Range` header, namely `bytes=0-1000` and `bytes=1001-`, for serving slices of files and enabling resumable downloads, etc.

* Support for returning partial files matching these slices on Unix and Windows platforms.

* Support for returning the appropriate `Content-Range` header and HTTP 206 responses for these requests.

* Tests for these features.

It does not support Windows as of yet, largely because I don't have a good test environment -- it should be possible to accomplish by passing some [`OVERLAPPED` structure](https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-overlapped) to `ReadFile()`.

There is also no support for advanced features such as [multipart ranges](https://tools.ietf.org/html/rfc7233#appendix-A) or [the `If-Range` header](https://tools.ietf.org/html/rfc7233#section-3.2).

Since `Range` header support is always optional (a server can just respond with the whole file and a HTTP 200 instead), we just fall back on existing behaviour in these cases instead of issuing some kind of error.

~Along these same lines, we don't yet advertise that we support the `Range` header by sending an [`Accept-Ranges: bytes` header](https://tools.ietf.org/html/rfc7233#section-2.3) on other GET/HEAD requests.~

Closes #259.