### PR TITLE
Add `timegm2()` function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 httpuv 1.6.0.9000
 =================
 
+* The `timegm()` function is a non-standard GNU extension, so it has been replaced with an internal `timegm2()` function. (#300)
 
 httpuv 1.6.0
 ============

--- a/src/timegm.cpp
+++ b/src/timegm.cpp
@@ -1,10 +1,12 @@
-#ifdef _WIN32
 #include "timegm.h"
+#include <time.h>
+#include <stdlib.h>
 
+#ifdef _WIN32
 #include <errno.h>
 #include <timezoneapi.h>
 
-time_t timegm(struct tm *tm) {
+time_t timegm2(struct tm *tm) {
   SYSTEMTIME st = {0};
   st.wYear = tm->tm_year + 1900;
   st.wMonth = tm->tm_mon + 1;
@@ -25,4 +27,25 @@ time_t timegm(struct tm *tm) {
   res.HighPart = ft.dwHighDateTime;
   return res.QuadPart / 10000000ULL - 11644473600ULL;
 }
+
+#else
+
+// We use this function instead of timegm(), because timegm() is a nonstandard
+// GNU extension.
+time_t timegm2(struct tm *tm) {
+  time_t ret;
+  char *tz;
+
+  tz = getenv("TZ");
+  setenv("TZ", "", 1);
+  tzset();
+  ret = mktime(tm);
+  if (tz)
+      setenv("TZ", tz, 1);
+  else
+      unsetenv("TZ");
+  tzset();
+  return ret;
+}
+
 #endif

--- a/src/timegm.h
+++ b/src/timegm.h
@@ -3,8 +3,6 @@
 
 #include <time.h>
 
-#ifdef _WIN32
-time_t timegm(struct tm *tm);
-#endif
+time_t timegm2(struct tm *tm);
 
 #endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -151,5 +151,5 @@ time_t parse_http_date_string(const std::string& date) {
     return 0;
   }
 
-  return timegm(&t);
+  return timegm2(&t);
 }


### PR DESCRIPTION
BDR sent a note saying that `timegm()` is a non-standard GNU extension and it should be removed. This PR implements and uses `timegm2()`.