### PR TITLE
Implement gzip compression

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: httpuv
 Type: Package
 Encoding: UTF-8
 Title: HTTP and WebSocket Server Library
-Version: 1.6.1.9000
+Version: 1.6.1.9001
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut"), email = "joe@rstudio.com"),
     person("Winston", "Chang", role = c("aut", "cre"), email = "winston@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ httpuv 1.6.1.9000
 
 * Fixed #282: `startPipeServer()` failed with "invalid argument" error after update to libuv 1.37.0. (#283)
 
+* Fixed #303: Don't return Content-Length header when the HTTP status is "101 Switching Protocols". (#305)
+
+* Added support for gzip-compressed HTTP responses. (#305)
+
 httpuv 1.6.1
 ============
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -2,7 +2,7 @@
 CXX_STD=CXX11
 
 PKG_LIBS = ./libuv/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o \
-	-lpthread -lws2_32 -lkernel32 -lpsapi -liphlpapi -lshell32 -luserenv
+	-lpthread -lws2_32 -lkernel32 -lpsapi -liphlpapi -lshell32 -luserenv -lz
 
 PKG_CFLAGS = $(C_VISIBILITY) -DSTRICT_R_HEADERS
 PKG_CXXFLAGS = $(CXX_VISIBILITY) -DSTRICT_R_HEADERS

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // sendWSMessage
 void sendWSMessage(SEXP conn, bool binary, Rcpp::RObject message);
 RcppExport SEXP _httpuv_sendWSMessage(SEXP connSEXP, SEXP binarySEXP, SEXP messageSEXP) {

--- a/src/gzipdatasource.cpp
+++ b/src/gzipdatasource.cpp
@@ -1,4 +1,5 @@
 #include "gzipdatasource.h"
+#include "utils.h"
 
 GZipDataSource::GZipDataSource(std::shared_ptr<DataSource> pData) :
   _pData(pData), _state(Streaming) {
@@ -21,7 +22,7 @@ GZipDataSource::~GZipDataSource() {
 }
 
 uint64_t GZipDataSource::size() const {
-  std::cerr << "GZipDataSource::size() was called, this should never happen\n";
+  debug_log("GZipDataSource::size() was called, this should never happen\n", LOG_WARN);
   return 0;
 }
 

--- a/src/gzipdatasource.cpp
+++ b/src/gzipdatasource.cpp
@@ -5,6 +5,7 @@ GZipDataSource::GZipDataSource(std::shared_ptr<DataSource> pData) :
   _pData(pData), _state(Streaming) {
 
   _zstrm = {0};
+  _inputBuf = {0};
   int res = deflateInit2(&_zstrm, 4, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
   if (res != Z_OK) {
     if (_zstrm.msg) {

--- a/src/gzipdatasource.cpp
+++ b/src/gzipdatasource.cpp
@@ -1,0 +1,96 @@
+#include "gzipdatasource.h"
+
+GZipDataSource::GZipDataSource(std::shared_ptr<DataSource> pData) :
+  _pData(pData), _state(Streaming) {
+
+  _zstrm = {0};
+  int res = deflateInit2(&_zstrm, 4, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
+  if (res != Z_OK) {
+    if (_zstrm.msg) {
+      throw std::runtime_error(_zstrm.msg);
+    } else {
+      throw std::runtime_error("zlib initialization failed");
+    }
+  }
+}
+
+GZipDataSource::~GZipDataSource() {
+  freeInputBuffer(true);
+  // ignore errors on destruction
+  deflateEnd(&_zstrm);
+}
+
+uint64_t GZipDataSource::size() const {
+  std::cerr << "GZipDataSource::size() was called, this should never happen\n";
+  return 0;
+}
+
+uv_buf_t GZipDataSource::getData(size_t bytesDesired) {
+  if (_state == Done) {
+    // GZip stream written, nothing more to do
+    return {0};
+  }
+
+  // Prepare the output area to be written to
+  Bytef* outputBuf = (Bytef*)malloc(bytesDesired);
+  _zstrm.next_out = outputBuf;
+  _zstrm.avail_out = bytesDesired;
+
+  // There's room to write, and things we need to write: if Streaming, then
+  // there's potentially more data; and if Finishing, then we need to write
+  // the gzip footer.
+  while (_zstrm.avail_out > 0 && _state != Done) {
+    if (_state == Streaming && _zstrm.avail_in == 0) {
+      freeInputBuffer();
+
+      _inputBuf = _pData->getData(bytesDesired);
+      _zstrm.next_in = (Bytef*)_inputBuf.base;
+      _zstrm.avail_in = _inputBuf.len;
+
+      if (_inputBuf.len == 0) {
+        _state = Finishing;
+      }
+    }
+
+    deflateNext();
+  }
+
+  freeInputBuffer();
+
+  uv_buf_t ret = {0};
+  ret.base = (char*)outputBuf;
+  ret.len = bytesDesired - _zstrm.avail_out;
+  return ret;
+}
+
+void GZipDataSource::freeData(uv_buf_t buffer) {
+  free(buffer.base);
+}
+
+void GZipDataSource::close() {
+  _pData->close();
+}
+
+// Attempt to deflate more data, reading from _zstrm.next_in and writing to
+// _zstrm.next_out. Both reads and (potentially) writes _state.
+void GZipDataSource::deflateNext() {
+  int res = deflate(&_zstrm, (_state == Finishing) ? Z_FINISH : Z_NO_FLUSH);
+  if (res == Z_STREAM_END) {
+    _state = Done;
+  } else if (res != Z_OK) {
+    throw std::runtime_error("deflate failed!");
+  }
+}
+
+// Use force=true to free the buffer even if _zstrm might still be using it
+bool GZipDataSource::freeInputBuffer(bool force) {
+  if ((force || _zstrm.avail_in == 0) && _inputBuf.base) {
+    _pData->freeData(_inputBuf);
+    _inputBuf = {0};
+    _zstrm.next_in = Z_NULL;
+    _zstrm.avail_in = 0;
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/src/gzipdatasource.cpp
+++ b/src/gzipdatasource.cpp
@@ -6,7 +6,7 @@ GZipDataSource::GZipDataSource(std::shared_ptr<DataSource> pData) :
 
   _zstrm = {0};
   _inputBuf = {0};
-  int res = deflateInit2(&_zstrm, 4, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
+  int res = deflateInit2(&_zstrm, 6, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
   if (res != Z_OK) {
     if (_zstrm.msg) {
       throw std::runtime_error(_zstrm.msg);

--- a/src/gzipdatasource.h
+++ b/src/gzipdatasource.h
@@ -1,0 +1,31 @@
+#ifndef GZIPDATASOURCE_H
+#define GZIPDATASOURCE_H
+
+#include <zlib.h>
+#include "uvutil.h"
+
+
+enum GDState { Streaming, Finishing, Done };
+
+class GZipDataSource : public DataSource {
+  std::shared_ptr<DataSource> _pData;
+  z_stream _zstrm;
+  uv_buf_t _inputBuf;
+  GDState _state;
+
+public:
+  GZipDataSource(std::shared_ptr<DataSource> pData);
+
+  ~GZipDataSource();
+
+  uint64_t size() const;
+  uv_buf_t getData(size_t bytesDesired);
+  void freeData(uv_buf_t buffer);
+  void close();
+
+private:
+  void deflateNext();
+  bool freeInputBuffer(bool force = false);
+};
+
+#endif // GZIPDATASOURCE_H

--- a/src/httpresponse.h
+++ b/src/httpresponse.h
@@ -18,6 +18,7 @@ class HttpResponse : public std::enable_shared_from_this<HttpResponse>  {
   std::vector<char> _responseHeader;
   std::shared_ptr<DataSource> _pBody;
   bool _closeAfterWritten;
+  bool _chunked;
 
 public:
   HttpResponse(std::shared_ptr<HttpRequest> pRequest,
@@ -28,7 +29,8 @@ public:
       _statusCode(statusCode),
       _status(status),
       _pBody(pBody),
-      _closeAfterWritten(false)
+      _closeAfterWritten(false),
+      _chunked(false)
   {
     _headers.push_back(std::make_pair("Date", http_date_string(time(NULL))));
   }

--- a/src/uvutil.cpp
+++ b/src/uvutil.cpp
@@ -145,8 +145,7 @@ void ExtendedWrite::next() {
       // In chunked mode, data chunks must be preceded by 1) the number of bytes
       // in the chunk, as a hexadecimal string; and 2) "\r\n"; and succeeded by
       // another "\r\n"
-      char prefix[16];
-      memset(prefix, 0, sizeof(prefix));
+      char prefix[16] = {0};
       int len = snprintf(prefix, sizeof(prefix), "%lX\r\n", buf.len);
       pWriteOp->setPrefix(prefix, len);
       pWriteOp->setSuffix(CRLF.c_str(), CRLF.length());

--- a/src/uvutil.cpp
+++ b/src/uvutil.cpp
@@ -21,16 +21,19 @@ public:
   }
 
   void setPrefix(const char* data, size_t len) {
+    ASSERT_BACKGROUND_THREAD()
     prefix.clear();
     std::copy(data, data + len, std::back_inserter(prefix));
   }
 
   void setSuffix(const char* data, size_t len) {
+    ASSERT_BACKGROUND_THREAD()
     suffix.clear();
     std::copy(data, data + len, std::back_inserter(suffix));
   }
 
   std::vector<uv_buf_t> bufs() {
+    ASSERT_BACKGROUND_THREAD()
     std::vector<uv_buf_t> res;
     if (prefix.size() > 0) {
       res.push_back(uv_buf_init(&prefix[0], prefix.size()));

--- a/src/uvutil.cpp
+++ b/src/uvutil.cpp
@@ -33,13 +33,11 @@ public:
   std::vector<uv_buf_t> bufs() {
     std::vector<uv_buf_t> res;
     if (prefix.size() > 0) {
-      uv_buf_t buf_prefix = {&prefix[0], prefix.size()};
-      res.push_back(buf_prefix);
+      res.push_back(uv_buf_init(&prefix[0], prefix.size()));
     }
     res.push_back(buffer);
     if (suffix.size() > 0) {
-      uv_buf_t buf_suffix = {&suffix[0], suffix.size()};
-      res.push_back(buf_suffix);
+      res.push_back(uv_buf_init(&suffix[0], suffix.size()));
     }
     return res;
   }

--- a/src/uvutil.h
+++ b/src/uvutil.h
@@ -67,14 +67,16 @@ public:
 // not to buffer too much data in memory (happens when you try
 // to write too much data to a slow uv_stream_t).
 class ExtendedWrite {
+  bool _chunked;
   int _activeWrites;
   bool _errored;
+  bool _completed;
   uv_stream_t* _pHandle;
   std::shared_ptr<DataSource> _pDataSource;
 
 public:
-  ExtendedWrite(uv_stream_t* pHandle, std::shared_ptr<DataSource> pDataSource)
-      : _activeWrites(0), _errored(false), _pHandle(pHandle),
+  ExtendedWrite(uv_stream_t* pHandle, std::shared_ptr<DataSource> pDataSource, bool chunked)
+      : _chunked(chunked), _activeWrites(0), _errored(false), _completed(false), _pHandle(pHandle),
         _pDataSource(pDataSource) {}
   virtual ~ExtendedWrite() {}
 

--- a/tests/testthat/helper-app.R
+++ b/tests/testthat/helper-app.R
@@ -79,7 +79,13 @@ extract <- function(promise) {
 
 
 # Make an HTTP request using curl.
-fetch <- function(url, handle = new_handle()) {
+fetch <- function(url, handle = curl::new_handle(), gzip = TRUE) {
+  if (!gzip) {
+    # Disable gzip; this is often needed only because the unit tests predate
+    # gzip support in httpuv
+    handle_setopt(handle, accept_encoding = NULL)
+  }
+
   p <- curl_fetch_async(url, handle = handle)
   extract(p)
 }

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -27,7 +27,7 @@ test_that("Basic functionality", {
   )
   expect_equal(length(listServers()), 2)
 
-  r1 <- fetch(local_url("/", s1$getPort()))
+  r1 <- fetch(local_url("/", s1$getPort()), gzip = FALSE)
   r2 <- fetch(local_url("/", s2$getPort()))
 
   expect_equal(r1$status_code, 200)
@@ -116,7 +116,7 @@ test_that("Content length depends on the presence of 'body'", {
   on.exit(s$stop())
   expect_equal(length(listServers()), 1)
 
-  r1 <- fetch(local_url("/ok", s$getPort()))
+  r1 <- fetch(local_url("/ok", s$getPort()), gzip = FALSE)
   # HEAD requests should not have a body.
   r2 <- fetch(local_url("/ok", s$getPort()), new_handle(nobody = TRUE))
   r3 <- fetch(local_url("/nullbody", s$getPort()))

--- a/tests/testthat/test-static-paths.R
+++ b/tests/testthat/test-static-paths.R
@@ -24,7 +24,7 @@ test_that("Basic static file serving", {
   on.exit(s$stop())
 
   # Fetch index.html
-  r <- fetch(local_url("/", s$getPort()))
+  r <- fetch(local_url("/", s$getPort()), gzip = FALSE)
   expect_equal(r$status_code, 200)
   expect_identical(r$content, index_file_content)
 
@@ -43,33 +43,33 @@ test_that("Basic static file serving", {
 
 
   # Testing index for other paths
-  r1 <- fetch(local_url("/1", s$getPort()))
+  r1 <- fetch(local_url("/1", s$getPort()), gzip = FALSE)
   h1 <- parse_headers_list(r1$headers)
   expect_identical(r$content, r1$content)
   expect_identical(h$`content-length`, h1$`content-length`)
   expect_identical(h$`content-type`, h1$`content-type`)
 
-  r2 <- fetch(local_url("/1/", s$getPort()))
+  r2 <- fetch(local_url("/1/", s$getPort()), gzip = FALSE)
   h2 <- parse_headers_list(r2$headers)
   expect_identical(r$content, r2$content)
   expect_identical(h$`content-length`, h2$`content-length`)
   expect_identical(h$`content-type`, h2$`content-type`)
 
-  r3 <- fetch(local_url("/1/index.html", s$getPort()))
+  r3 <- fetch(local_url("/1/index.html", s$getPort()), gzip = FALSE)
   h3 <- parse_headers_list(r3$headers)
   expect_identical(r$content, r3$content)
   expect_identical(h$`content-length`, h3$`content-length`)
   expect_identical(h$`content-type`, h3$`content-type`)
 
   # Missing file (404)
-  r <- fetch(local_url("/foo", s$getPort()))
+  r <- fetch(local_url("/foo", s$getPort()), gzip = FALSE)
   h <- parse_headers_list(r$headers)
   expect_equal(r$status_code, 404)
   expect_identical(rawToChar(r$content), "404 Not Found\n")
   expect_equal(h$`content-length`, "14")
 
   # Missing directory in path (404)
-  r <- fetch(local_url("/foo/bar", s$getPort()))
+  r <- fetch(local_url("/foo/bar", s$getPort()), gzip = FALSE)
   h <- parse_headers_list(r$headers)
   expect_equal(r$status_code, 404)
   expect_identical(rawToChar(r$content), "404 Not Found\n")
@@ -651,13 +651,13 @@ test_that("HEAD, POST, PUT requests", {
   on.exit(s$stop())
 
   # The GET results, for comparison to HEAD.
-  r_get <- fetch(local_url("/static", s$getPort()))
+  r_get <- fetch(local_url("/static", s$getPort()), gzip = FALSE)
   h_get <- parse_headers_list(r_get$headers)
 
   # HEAD is OK.
   # Note the weird interface for a HEAD request:
   # https://github.com/jeroen/curl/issues/24
-  r <- fetch(local_url("/static", s$getPort()), new_handle(nobody = TRUE))
+  r <- fetch(local_url("/static", s$getPort()), new_handle(nobody = TRUE), gzip = FALSE)
   expect_equal(r$status_code, 200)
   expect_true(length(r$content) == 0)  # No message body for HEAD
   h <- parse_headers_list(r$headers)


### PR DESCRIPTION
(Incidentally, fixes #303)

A Connect customer was seeing significantly slower loading times (accessing through a VPN) than with a previous setup using Shiny Server. Shiny Server does its own gzip compression, but Connect just passes through whatever it gets from Shiny. It felt to me like httpuv should just do this.

This implementation uses zlib in streaming mode, so Content-Length headers are no longer returned (when gzipped); instead the response is sent using chunked encoding.

One open question with this PR is that it currently makes the decision about gzip vs. no gzip pretty late, like right before the headers are sent. One of the things it takes into consideration is whether there is a body. This means that HEAD requests for a resource that would be gzipped, returns different headers than the equivalent GET (the former returns `Content-Length`, the latter does not; and the latter returns `Content-Encoding: gzip` and `Transfer-Encoding: chunked` which the former does not). It'd be ideal if the headers were exactly the same.