### PR TITLE
Bump required version of Rcpp to 1.0.7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ License: GPL (>= 2) | file LICENSE
 Depends:
     R (>= 2.15.1)
 Imports:
-    Rcpp (>= 0.11.0),
+    Rcpp (>= 1.0.7),
     utils,
     R6,
     promises,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-# httpuv (development version)
+httpuv (development version)
+============
+
+* Increased required version of Rcpp to 1.0.7, to work around an incompatibility between Rcpp 1.0.6 and packages compiled with Rcpp 1.0.7.
 
 httpuv 1.6.2
 ============


### PR DESCRIPTION
This is so that users don't run into the incompatibility between Rcpp 1.0.6 and packages compiled with Rcpp 1.0.7.