### PR TITLE
Add zlib to SystemRequirements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     later (>= 0.8.0)
 LinkingTo: Rcpp, later
 URL: https://github.com/rstudio/httpuv
-SystemRequirements: GNU make, C++11
+SystemRequirements: GNU make, C++11, zlib
 RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)
 Suggests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 httpuv 1.6.3.9000 (development)
 ============
 
+* Added zlib to SystemRequirements in DESCRIPTION file. (#315)
 
 httpuv 1.6.3
 ============


### PR DESCRIPTION
This PR addresses an issue which I received via email:


> 
> I'm the maintainer of a binary CRAN mirror for opensuse in OBS (build.opensuse.org).
> 
> (if interested see https://build.opensuse.org/package/show/devel:languages:R:autoCRAN/R-httpuv)
> 
> Your package "httpuv" misses to declare zlib (resp zlib-devel) in SystemRequirements in the DESCRIPTION file.
> 
> Would be great, if that could be added, as without the package building process can't know about it and fails.
> 
> SystemRequirements: GNU make, C++11, zlib
> 
> would suffice.
> 