### PR TITLE
Fix builds when a newer automake is present

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Imports:
 LinkingTo: Rcpp, later
 URL: https://github.com/rstudio/httpuv
 SystemRequirements: GNU make, C++11, zlib
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 Suggests:
     testthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: httpuv
 Type: Package
 Encoding: UTF-8
 Title: HTTP and WebSocket Server Library
-Version: 1.6.3.9000
+Version: 1.6.3.9001
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut"), email = "joe@rstudio.com"),
     person("Winston", "Chang", role = c("aut", "cre"), email = "winston@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
-httpuv 1.6.3.9000 (development)
+httpuv 1.6.3.9001 (development)
 ============
 
 * Added zlib to SystemRequirements in DESCRIPTION file. (#315)
+
+* Closed #280: Fix builds on Alpine Linux (and other versions which have automake >1.16.1). (#319)
 
 httpuv 1.6.3
 ============

--- a/src/Makevars
+++ b/src/Makevars
@@ -76,6 +76,8 @@ libuv/Makefile: libuv/m4/lt~obsolete.m4
 		echo "automake not found. Touching files so configure will not try to run automake."; \
 		touch aclocal.m4; \
 		touch -r aclocal.m4 configure Makefile.in; \
+	else \
+		touch configure.ac; \
 	fi; \
 	chmod +x configure; \
 	CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(C_VISIBILITY)" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure $(CONFIGURE_FLAGS)

--- a/src/Makevars
+++ b/src/Makevars
@@ -50,10 +50,18 @@ $(SHLIB): libuv/.libs/libuv.a http-parser/http_parser.o sha1/sha1.o base64/base6
 libuv/m4/lt~obsolete.m4: libuv/m4/lt_obsolete.m4
 	cp -p -f libuv/m4/lt_obsolete.m4 libuv/m4/lt~obsolete.m4
 
-# Run ./configure. We need to touch various autotools-related files to avoid
-# it trying to run autotools programs again. We also need to make sure
-# configure is executable, because on some platforms, calling unzip() in R
-# does not preserve the executable bit.
+# Run ./configure to create the Makefile.
+#
+# On systems that do _not_ have automake installed, we need to make sure that
+# configure does not try to run automake, because it will fail. To do that, we
+# we need to touch various autotools-related files so it doesn't try to run
+# autotools programs again. We also need to make sure configure is executable,
+# because on some platforms, calling unzip() in R does not preserve the
+# executable bit.
+#
+# If the system does have automake, then we'll just run configure; it may in
+# turn run automake if the version of automake on the system is newer than the
+# one used when the configure file was created.
 #
 # It's VERY IMPORTANT that mtime(aclocal.m4) <= mtime(configure), and also
 # mtime(aclocal.m4) <= mtime(Makefile.in). On some platforms, passing multiple

--- a/src/Makevars
+++ b/src/Makevars
@@ -89,8 +89,8 @@ libuv/Makefile: libuv/m4/lt~obsolete.m4
 		touch aclocal.m4; \
 		touch -r aclocal.m4 configure Makefile.in; \
 	else \
-		echo "automake found. Touching configure.ac."; \
-		touch configure.ac; \
+		echo "automake found. Running autogen.sh."; \
+		sh autogen.sh; \
 	fi; \
 	chmod +x configure; \
 	CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(C_VISIBILITY)" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure $(CONFIGURE_FLAGS)

--- a/src/Makevars
+++ b/src/Makevars
@@ -59,9 +59,9 @@ libuv/m4/lt~obsolete.m4: libuv/m4/lt_obsolete.m4
 # because on some platforms, calling unzip() in R does not preserve the
 # executable bit.
 #
-# If the system does have automake, then we'll just run configure; it may in
-# turn run automake if the version of automake on the system is newer than the
-# one used when the configure file was created.
+# If the system does have automake, then we'll run autogen.sh before configure,
+# as per the official build instructions for libuv. autogen.sh will in turn run
+# aclocal, autoconf, and automake.
 #
 # It's VERY IMPORTANT that mtime(aclocal.m4) <= mtime(configure), and also
 # mtime(aclocal.m4) <= mtime(Makefile.in). On some platforms, passing multiple
@@ -72,18 +72,6 @@ libuv/m4/lt~obsolete.m4: libuv/m4/lt_obsolete.m4
 # precisely the same timestamp value.
 libuv/Makefile: libuv/m4/lt~obsolete.m4
 	cd libuv; \
-	if ! command -v automake >/dev/null 2>&1 ; then \
-		echo "automake NOT FOUND"; \
-	else \
-		echo "automake FOUND"; \
-		automake --version; \
-	fi; \
-	if ! command -v autoconf >/dev/null 2>&1 ; then \
-		echo "autoconf NOT FOUND"; \
-	else \
-		echo "autoconf FOUND"; \
-		autoconf --version; \
-	fi; \
 	if ! command -v automake >/dev/null 2>&1 ; then \
 		echo "automake not found. Touching files so configure will not try to run automake."; \
 		touch aclocal.m4; \

--- a/src/Makevars
+++ b/src/Makevars
@@ -63,11 +63,14 @@ libuv/m4/lt~obsolete.m4: libuv/m4/lt_obsolete.m4
 # use "-r aclocal.m4" to ensure that all three files are guaranteed to have
 # precisely the same timestamp value.
 libuv/Makefile: libuv/m4/lt~obsolete.m4
-	(cd libuv \
-		&& touch aclocal.m4 \
-		&& touch -r aclocal.m4 configure Makefile.in \
-		&& chmod +x configure \
-		&& CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(C_VISIBILITY)" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure $(CONFIGURE_FLAGS))
+	cd libuv; \
+	if [! command -v automake >/dev/null 2>&1 ]; then \
+		echo "automake not found. Touching files so configure will not try to run automake."; \
+		touch aclocal.m4; \
+		touch -r aclocal.m4 configure Makefile.in; \
+	fi; \
+	chmod +x configure; \
+	CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(C_VISIBILITY)" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure $(CONFIGURE_FLAGS)
 
 libuv/.libs/libuv.a: libuv/Makefile
 	$(MAKE) --directory=libuv \

--- a/src/Makevars
+++ b/src/Makevars
@@ -76,11 +76,13 @@ libuv/Makefile: libuv/m4/lt~obsolete.m4
 		echo "automake NOT FOUND"; \
 	else \
 		echo "automake FOUND"; \
+		automake --version; \
 	fi; \
 	if ! command -v autoconf >/dev/null 2>&1 ; then \
 		echo "autoconf NOT FOUND"; \
 	else \
 		echo "autoconf FOUND"; \
+		autoconf --version; \
 	fi; \
 	if ! command -v automake >/dev/null 2>&1 ; then \
 		echo "automake not found. Touching files so configure will not try to run automake."; \

--- a/src/Makevars
+++ b/src/Makevars
@@ -72,7 +72,7 @@ libuv/m4/lt~obsolete.m4: libuv/m4/lt_obsolete.m4
 # precisely the same timestamp value.
 libuv/Makefile: libuv/m4/lt~obsolete.m4
 	cd libuv; \
-	if [! command -v automake >/dev/null 2>&1 ]; then \
+	if ! command -v automake >/dev/null 2>&1 ; then \
 		echo "automake not found. Touching files so configure will not try to run automake."; \
 		touch aclocal.m4; \
 		touch -r aclocal.m4 configure Makefile.in; \

--- a/src/Makevars
+++ b/src/Makevars
@@ -73,6 +73,16 @@ libuv/m4/lt~obsolete.m4: libuv/m4/lt_obsolete.m4
 libuv/Makefile: libuv/m4/lt~obsolete.m4
 	cd libuv; \
 	if ! command -v automake >/dev/null 2>&1 ; then \
+		echo "automake NOT FOUND"; \
+	else \
+		echo "automake FOUND"; \
+	fi; \
+	if ! command -v autoconf >/dev/null 2>&1 ; then \
+		echo "autoconf NOT FOUND"; \
+	else \
+		echo "autoconf FOUND"; \
+	fi; \
+	if ! command -v automake >/dev/null 2>&1 ; then \
 		echo "automake not found. Touching files so configure will not try to run automake."; \
 		touch aclocal.m4; \
 		touch -r aclocal.m4 configure Makefile.in; \

--- a/src/Makevars
+++ b/src/Makevars
@@ -77,6 +77,7 @@ libuv/Makefile: libuv/m4/lt~obsolete.m4
 		touch aclocal.m4; \
 		touch -r aclocal.m4 configure Makefile.in; \
 	else \
+		echo "automake found. Touching configure.ac."; \
 		touch configure.ac; \
 	fi; \
 	chmod +x configure; \


### PR DESCRIPTION
This is fixes #280.

Tested on Mac, and on an Alpine container build with this Dockerfile:

```Dockerfile
FROM rhub/r-minimal:latest

RUN apk update && \
    apk add libcurl && \
    apk add g++ && \
    apk add gcc && \
    apk add linux-headers && \
    apk add gfortran && \
    apk add automake libtool m4 autoconf linux-headers && \
    apk add openssl

RUN apk add --no-cache \
    autoconf=2.69-r2 \
    automake=1.16.2-r0 \
    build-base=0.5-r2 \
    R \
    R-dev && \
    apk add --no-cache --virtual .build-deps \
    wget=1.20.3-r1 && \
    apk del .build-deps

RUN echo 'options(\n\
  repos = c(CRAN = "https://cloud.r-project.org/"),\n\
  download.file.method = "libcurl",\n\
  # Detect number of physical cores\n\
  Ncpus = parallel::detectCores(logical=FALSE)\n\
)' >> /etc/R/Rprofile.site

RUN R -e "install.packages('remotes', repos = c(CRAN = 'https://cloud.r-project.org')); \
    install.packages('renv', repos = c(CRAN = 'https://cloud.r-project.org')); \
    renv::restore(repos = c(CRAN = 'https://cloud.r-project.org')); \
    renv::clean();"

RUN R -e "install.packages(c('Rcpp', 'R6', 'promises', 'later'), repos = c(CRAN = 'https://cloud.r-project.org') )"

CMD ["/bin/bash"]
```

To build the Docker image, run it, and install httpuv:

```
docker build -t alpinehttpuv .
docker run --rm -ti alpinehttpuv
R
remotes::install_github('rstudio/httpuv@fix-automake')
```