### PR TITLE
Use libuv headers from compiler search path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ httpuv 1.6.4.9000
 
 * Added support for R on Windows UCRT. (#324)
 
+* When using a system-wide copy of libuv, httpuv will now compile using the system-wide headers for libuv, instead of the local copy of the libuv headers. (#327)
+
 httpuv 1.6.4
 ============
 

--- a/src/callbackqueue.cpp
+++ b/src/callbackqueue.cpp
@@ -2,7 +2,7 @@
 #include "callbackqueue.h"
 #include "tqueue.h"
 #include "thread.h"
-#include "libuv/include/uv.h"
+#include <uv.h>
 
 
 // This non-class function is a plain C wrapper for CallbackQueue::flush(), and

--- a/src/callbackqueue.h
+++ b/src/callbackqueue.h
@@ -3,7 +3,7 @@
 
 #include "tqueue.h"
 #include <functional>
-#include "libuv/include/uv.h"
+#include <uv.h>
 
 class CallbackQueue {
 public:

--- a/src/http.h
+++ b/src/http.h
@@ -1,7 +1,7 @@
 #ifndef HTTP_HPP
 #define HTTP_HPP
 
-#include "libuv/include/uv.h"
+#include <uv.h>
 #include <memory>
 #include <functional>
 #include "webapplication.h"

--- a/src/httprequest.h
+++ b/src/httprequest.h
@@ -6,7 +6,7 @@
 
 #include <functional>
 #include <memory>
-#include "libuv/include/uv.h"
+#include <uv.h>
 #include "http-parser/http_parser.h"
 #include "socket.h"
 #include "webapplication.h"

--- a/src/httpresponse.cpp
+++ b/src/httpresponse.cpp
@@ -4,7 +4,7 @@
 #include "thread.h"
 #include "utils.h"
 #include "gzipdatasource.h"
-#include "libuv/include/uv.h"
+#include <uv.h>
 
 
 void on_response_written(uv_write_t* handle, int status) {

--- a/src/httpuv.cpp
+++ b/src/httpuv.cpp
@@ -7,7 +7,7 @@
 #include <errno.h>
 #include <functional>
 #include <memory>
-#include "libuv/include/uv.h"
+#include <uv.h>
 #include "base64/base64.hpp"
 #include "uvutil.h"
 #include "webapplication.h"

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -1,7 +1,7 @@
 #include "socket.h"
 #include "httprequest.h"
 #include <later_api.h>
-#include "libuv/include/uv.h"
+#include <uv.h>
 
 void on_Socket_close(uv_handle_t* pHandle);
 

--- a/src/socket.h
+++ b/src/socket.h
@@ -3,7 +3,7 @@
 
 #include "http.h"
 #include <memory>
-#include "libuv/include/uv.h"
+#include <uv.h>
 
 class HttpRequest;
 class WebApplication;

--- a/src/thread.h
+++ b/src/thread.h
@@ -1,7 +1,7 @@
 #ifndef THREAD_HPP
 #define THREAD_HPP
 
-#include "libuv/include/uv.h"
+#include <uv.h>
 
 // These must be called from the main and background thread, respectively, so
 // that is_main_thread() and is_background_thread() can be tested later.

--- a/src/uvutil.h
+++ b/src/uvutil.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 #include <memory>
-#include "libuv/include/uv.h"
+#include <uv.h>
 
 #include <Rcpp.h>
 

--- a/src/webapplication.h
+++ b/src/webapplication.h
@@ -2,7 +2,7 @@
 #define WEBAPPLICATION_HPP
 
 #include <functional>
-#include "libuv/include/uv.h"
+#include <uv.h>
 #include <Rcpp.h>
 #include "websockets.h"
 #include "thread.h"


### PR DESCRIPTION
This change is borrowed from #326, and is motivated by the use of a system-wide libuv library from Windows UCRT.

Before this change, when compiling httpuv, it would always use the local copy of the libuv headers (in `src/libuv/include/`). This is correct when httpuv is linked with the local copy of the libuv DLL, but it is wrong when it is linked against the system copy of libuv (in `/usr/lib/` or similar), which is the case with Windows UCRT.

After this change, when linking to the local copy of libuv (in `src/libuv/`), it will compile with the local headers; but when linking to the system copy of libuv, it will compile with the system headers.