### PR TITLE
Use `AppExecLinkReparseBuffer` by name

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,6 +1,7 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 /\.mailmap$
+/\.readthedocs.yaml$
 /\.git$
 /\.o$
 /\.so$

--- a/src/README.md
+++ b/src/README.md
@@ -58,6 +58,8 @@ To update libuv to a new version, do the following:
     # Fixes for unnamed structs on MinGW
     git cherry-pick 7106577
     git cherry-pick 4bea58e
+    # Fix for incompatible pointer type on MinGW
+    git cherry-pick ef944cf
     # Fix for empty translation unit warning on Windows with -pedantic
     git cherry-pick 8ab31ef
     # Fix for Solaris

--- a/src/README.md
+++ b/src/README.md
@@ -55,8 +55,9 @@ To update libuv to a new version, do the following:
 * Cherry-pick some fixes:
 
     ```
-    # Fix for unnamed structs on MinGW
+    # Fixes for unnamed structs on MinGW
     git cherry-pick 7106577
+    git cherry-pick 4bea58e
     # Fix for empty translation unit warning on Windows with -pedantic
     git cherry-pick 8ab31ef
     # Fix for Solaris

--- a/src/libuv/src/win/fs.c
+++ b/src/libuv/src/win/fs.c
@@ -401,11 +401,11 @@ INLINE static int fs__readlink_handle(HANDLE handle, char** target_ptr,
 
   } else if (reparse_data->ReparseTag == IO_REPARSE_TAG_APPEXECLINK) {
     /* String #3 in the list has the target filename. */
-    if (reparse_data->AppExecLinkReparseBuffer.StringCount < 3) {
+    if (reparse_data->u.AppExecLinkReparseBuffer.StringCount < 3) {
       SetLastError(ERROR_SYMLINK_NOT_SUPPORTED);
       return -1;
     }
-    w_target = reparse_data->AppExecLinkReparseBuffer.StringList;
+    w_target = reparse_data->u.AppExecLinkReparseBuffer.StringList;
     /* The StringList buffer contains a list of strings separated by "\0",   */
     /* with "\0\0" terminating the list. Move to the 3rd string in the list: */
     for (i = 0; i < 2; ++i) {

--- a/src/libuv/src/win/udp.c
+++ b/src/libuv/src/win/udp.c
@@ -1087,7 +1087,7 @@ int uv__udp_disconnect(uv_udp_t* handle) {
 
     memset(&addr, 0, sizeof(addr));
 
-    err = connect(handle->socket, &addr, sizeof(addr));
+    err = connect(handle->socket, (struct sockaddr*) &addr, sizeof(addr));
     if (err)
       return uv_translate_sys_error(WSAGetLastError());
 


### PR DESCRIPTION
Prior art https://github.com/rstudio/httpuv/commit/3e2621d107a647b2781ed6b997e855180d058a0a
Related breaking change: https://github.com/rstudio/httpuv/commit/ca370b4aff2578d3f8e8d9146b759e07d32ded0f#diff-63d59b2613aaf4f6bc6608efa6cc2b09395f3e6fbdb125996a1518f296f8d951R404-R408

Error seen:
```
  OE> C:/rtools40/mingw32/bin/gcc  -O2 -Wall  -std=gnu99 -mfpmath=sse -msse2 -mstackrealign  -Wall -pedantic -Iinclude -Isrc -Isrc/win -DWIN32_LEAN_AND_MEAN -D_WIN32_WINNT=0x0600   -c -o src/win/fs.o src/win/fs.c
  OE> src/win/fs.c: In function 'fs__readlink_handle':
  OE> src/win/fs.c:404:21: error: 'REPARSE_DATA_BUFFER' {aka 'struct _REPARSE_DATA_BUFFER'} has no member named 'AppExecLinkReparseBuffer'
  OE>      if (reparse_data->AppExecLinkReparseBuffer.StringCount < 3) {
  OE>                      ^~
  OE> src/win/fs.c:408:28: error: 'REPARSE_DATA_BUFFER' {aka 'struct _REPARSE_DATA_BUFFER'} has no member named 'AppExecLinkReparseBuffer'
  OE>      w_target = reparse_data->AppExecLinkReparseBuffer.StringList;
  OE>                             ^~
  OE> make[1]: *** [Makefile-libuv.mingw:26: src/win/fs.o] Error 1
  OE> make[1]: Leaving directory '/c/Users/runneradmin/AppData/Local/Temp/Rtmp8YsjfN/R.INSTALL17083f8f2a9f/httpuv/src-i386/libuv'
  OE> make: *** [Makevars.win:22: libuv/libuv.a] Error 2
  OE> ERROR: compilation failed for package 'httpuv'
  OE> * removing 'C:/Users/RUNNER~1/AppData/Local/Temp/Rtmp48RRag/pkg-lib155424732a9a/httpuv'
```

---------------------

`SymbolicLinkReparseBuffer`, `MountPointReparseBuffer`, and `GenericReparseBuffer` look correct. 

Only `AppExecLinkReparseBuffer` was missing.