### PR TITLE
Use leading zeros for `encodeURI()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ httpuv 1.6.5.9000
 
 * Updated to libuv 1.43.0. (#328)
 
+* Fixed #336: `encodeURI()` and `encodeURIComponent()` printed a space instead of a leading zero, as in `"% A"` instead of `"%0A"`. (#337)
+
 httpuv 1.6.5
 ============
 

--- a/src/httpuv.cpp
+++ b/src/httpuv.cpp
@@ -500,7 +500,7 @@ std::string doEncodeURI(std::string value, bool encodeReserved) {
     if (!needsEscape(*it, encodeReserved)) {
       os << *it;
     } else {
-      os << '%' << std::setw(2) << static_cast<unsigned int>(static_cast<unsigned char>(*it));
+      os << '%' << std::setw(2) << std::setfill('0') << static_cast<unsigned int>(static_cast<unsigned char>(*it));
     }
   }
   return os.str();

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -4,8 +4,8 @@ test_that("encodeURI and encodeURIComponent", {
   # "abc \ue5 \u4e2d" is identical to "abc å 中" when the system's encoding is
   # UTF-8. However, the former is always encoded as UTF-8, while the latter will
   # be encoded using the system's native encoding.
-  utf8_str             <- "abc \ue5 \u4e2d"
-  utf8_str_encoded     <- "abc%20%C3%A5%20%E4%B8%AD"
+  utf8_str             <- "abc \ue5 \u4e2d\r\n"
+  utf8_str_encoded     <- "abc%20%C3%A5%20%E4%B8%AD%0D%0A"
   reserved_str         <- ",/?:@"
   reserved_str_encoded <- "%2C%2F%3F%3A%40"
 


### PR DESCRIPTION
Closes #336.