### PR TITLE
Fixes for older macOS

### DIFF
--- a/src/libuv/src/unix/core.c
+++ b/src/libuv/src/unix/core.c
@@ -531,18 +531,30 @@ int uv__accept(int sockfd) {
  * will unwind the thread when it's in the cancel state. Work around that
  * by making the system call directly. Musl libc is unaffected.
  */
+#if defined(__GNUC__)
+# define GCC_VERSION \
+	(__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#endif
+#if defined(__clang__) || (defined(GCC_VERSION) && (GCC_VERSION >= 40500))
+/* gcc diagnostic pragmas available */
+# define GCC_DIAGNOSTIC_AVAILABLE
+#endif
 int uv__close_nocancel(int fd) {
-#if defined(__APPLE__)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdollar-in-identifier-extension"
-#if defined(__LP64__) || TARGET_OS_IPHONE
+#if defined(__APPLE__) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1050)
+# if defined(GCC_DIAGNOSTIC_AVAILABLE)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdollar-in-identifier-extension"
+# endif
+# if defined(__LP64__) || __LP64__ || (defined(TARGET_OS_IPHONE) && (TARGET_OS_IPHONE > 0))
   extern int close$NOCANCEL(int);
   return close$NOCANCEL(fd);
-#else
+# else
   extern int close$NOCANCEL$UNIX2003(int);
   return close$NOCANCEL$UNIX2003(fd);
-#endif
-# pragma GCC diagnostic pop
+# endif
+# if defined(GCC_DIAGNOSTIC_AVAILABLE)
+#  pragma GCC diagnostic pop
+# endif
 #elif defined(__linux__) && defined(__SANITIZE_THREAD__) && defined(__clang__)
   long rc;
   __sanitizer_syscall_pre_close(fd);

--- a/src/libuv/src/unix/darwin-proctitle.c
+++ b/src/libuv/src/unix/darwin-proctitle.c
@@ -41,9 +41,11 @@ static int uv__pthread_setname_np(const char* name) {
   strncpy(namebuf, name, sizeof(namebuf) - 1);
   namebuf[sizeof(namebuf) - 1] = '\0';
 
+#if TARGET_OS_IPHONE || (MAC_OS_X_VERSION_MIN_REQUIRED >= 1060)
   err = pthread_setname_np(namebuf);
   if (err)
     return UV__ERR(err);
+#endif
 
   return 0;
 }

--- a/src/libuv/src/unix/fs.c
+++ b/src/libuv/src/unix/fs.c
@@ -1060,7 +1060,7 @@ static ssize_t uv__fs_sendfile(uv_fs_t* req) {
 
     return -1;
   }
-#elif defined(__APPLE__)           || \
+#elif (defined(__APPLE__) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1050)) || \
       defined(__DragonFly__)       || \
       defined(__FreeBSD__)         || \
       defined(__FreeBSD_kernel__)
@@ -1427,7 +1427,7 @@ static void uv__to_stat(struct stat* src, uv_stat_t* dst) {
   dst->st_blksize = src->st_blksize;
   dst->st_blocks = src->st_blocks;
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1050)
   dst->st_atim.tv_sec = src->st_atimespec.tv_sec;
   dst->st_atim.tv_nsec = src->st_atimespec.tv_nsec;
   dst->st_mtim.tv_sec = src->st_mtimespec.tv_sec;

--- a/src/libuv/src/unix/tty.c
+++ b/src/libuv/src/unix/tty.c
@@ -72,7 +72,7 @@ static int uv__tty_is_slave(const int fd) {
   int dummy;
 
   result = ioctl(fd, TIOCGPTN, &dummy) != 0;
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
   char dummy[256];
 
   result = ioctl(fd, TIOCPTYGNAME, &dummy) != 0;

--- a/src/libuv/src/unix/udp.c
+++ b/src/libuv/src/unix/udp.c
@@ -927,6 +927,7 @@ static int uv__udp_set_membership6(uv_udp_t* handle,
     !defined(__NetBSD__) &&                                         \
     !defined(__ANDROID__) &&                                        \
     !defined(__DragonFly__) &&                                      \
+    (!defined(__APPLE__) || (MAC_OS_X_VERSION_MAX_ALLOWED >= 1070)) && \
     !defined(__QNX__)
 static int uv__udp_set_source_membership4(uv_udp_t* handle,
                                           const struct sockaddr_in* multicast_addr,
@@ -1119,6 +1120,7 @@ int uv_udp_set_source_membership(uv_udp_t* handle,
     !defined(__NetBSD__) &&                                         \
     !defined(__ANDROID__) &&                                        \
     !defined(__DragonFly__) &&                                      \
+    (!defined(__APPLE__) || (MAC_OS_X_VERSION_MAX_ALLOWED >= 1070)) && \
     !defined(__QNX__)
   int err;
   union uv__sockaddr mcast_addr;


### PR DESCRIPTION
This PR is based on patches used in Macports for building `libuv`: https://github.com/macports/macports-ports/tree/master/devel/libuv/files

P. S. I am bringing R packages into Macports now, and `httpuv` among them, and we want everything to build on Leopard up; it is desirable to have it fixed with upstream rather than keep carrying our local patch.