### PR TITLE
Fix race condition between `Barrier` destructor and `Barrier.wait()`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,4 +20,4 @@ jobs:
   R-CMD-check:
     uses: rstudio/shiny-workflows/.github/workflows/R-CMD-check.yaml@v1
     with:
-      ubuntu: "ubuntu-18.04 ubuntu-20.04"
+      ubuntu: "ubuntu-20.04 ubuntu-latest"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: httpuv
 Type: Package
 Encoding: UTF-8
 Title: HTTP and WebSocket Server Library
-Version: 1.6.7.9000
+Version: 1.6.7.9001
 Authors@R: c(
     person("Joe", "Cheng", role = c("aut"), email = "joe@rstudio.com"),
     person("Winston", "Chang", role = c("aut", "cre"), email = "winston@rstudio.com"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Imports:
 LinkingTo: Rcpp, later
 URL: https://github.com/rstudio/httpuv
 SystemRequirements: GNU make, C++11, zlib
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 Suggests:
     testthat,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
-# httpuv 1.6.7.9000
+# httpuv 1.6.7.9001
 
+* Fixed #351: A race condition could cause httpuv to crash when starting the background thread for I/O. (#352)
 
 # httpuv 1.6.7
 

--- a/src/httpuv.cpp
+++ b/src/httpuv.cpp
@@ -111,7 +111,7 @@ void block_sigpipe() {
 
 void io_thread(void* data) {
   register_background_thread();
-  Barrier* blocker = reinterpret_cast<Barrier*>(data);
+  std::shared_ptr<Barrier>* pBlocker = reinterpret_cast<std::shared_ptr<Barrier>*>(data);
 
   io_thread_running.set(true);
 
@@ -123,7 +123,8 @@ void io_thread(void* data) {
   uv_async_init(io_loop.get(), &async_stop_io_loop, stop_io_loop);
 
   // Tell other thread that it can continue.
-  blocker->wait();
+  (*pBlocker)->wait();
+  delete pBlocker;
 
   // Must ignore SIGPIPE for libuv code; otherwise unexpectedly closed
   // connections kill us. https://github.com/rstudio/httpuv/issues/168
@@ -151,10 +152,17 @@ void ensure_io_thread() {
     return;
   }
 
-  Barrier blocker(2);
-  int ret = uv_thread_create(&io_thread_id, io_thread, &blocker);
+  // Use a shared_ptr because the lifetime of this object might be longer than
+  // this function, since it is passed to the background thread.
+  std::shared_ptr<Barrier> blocker = std::make_shared<Barrier>(2);
+
+  // We want to pass a copy of the shared_ptr to the new pthread. To do that, we
+  // need to create a new shared_ptr and get the regular pointer to it.
+  std::shared_ptr<Barrier>* pBlocker = new std::shared_ptr<Barrier>(blocker);
+
+  int ret = uv_thread_create(&io_thread_id, io_thread, pBlocker);
   // Wait for io_loop to be initialized before continuing
-  blocker.wait();
+  blocker->wait();
 
   if (ret != 0) {
     Rcpp::stop(std::string("Error: ") + uv_strerror(ret));

--- a/src/httpuv.cpp
+++ b/src/httpuv.cpp
@@ -112,6 +112,8 @@ void block_sigpipe() {
 void io_thread(void* data) {
   register_background_thread();
   std::shared_ptr<Barrier>* pBlocker = reinterpret_cast<std::shared_ptr<Barrier>*>(data);
+  std::shared_ptr<Barrier> blocker = std::shared_ptr<Barrier>(*pBlocker);
+  delete pBlocker;
 
   io_thread_running.set(true);
 
@@ -123,8 +125,7 @@ void io_thread(void* data) {
   uv_async_init(io_loop.get(), &async_stop_io_loop, stop_io_loop);
 
   // Tell other thread that it can continue.
-  (*pBlocker)->wait();
-  delete pBlocker;
+  blocker->wait();
 
   // Must ignore SIGPIPE for libuv code; otherwise unexpectedly closed
   // connections kill us. https://github.com/rstudio/httpuv/issues/168


### PR DESCRIPTION
Closes #351. This eliminates the race condition between the `Barrier` destructor and a call to `Barrier.wait()`.

Test code:

```
for i in {1..16}; do
    yes > /dev/null &
done

for i in {1..50}; do
    Rscript -e "s <- httpuv::startServer('0.0.0.0', 8000, list()); cat('.')"
done

killall yes
```