### PR TITLE
Use `.clear()` instead of `.empty()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # httpuv 1.6.8.9000
 
+* Fixed #354: The incorrect method was called to clear a `vector`. (#355)
 
 # httpuv 1.6.8
 

--- a/src/httprequest.cpp
+++ b/src/httprequest.cpp
@@ -805,7 +805,7 @@ void HttpRequest::_parse_http_data(char* buffer, const ssize_t n) {
       if (body.size() > 0) {
         pDS->add(body);
       }
-      body.empty();
+      body.clear();
 
       pResp->writeResponse();
 


### PR DESCRIPTION
This fixes #354.

I don't think there should be a change in behavior. With the old code, the vector wasn't cleared immediately, but once it went out of scope (at the end of the `if` block), it would be destroyed and the memory would be reclaimed. With the new code, the only difference is that the vector is cleared and the memory is reclaimed earlier.