### PR TITLE
Set `CXX_STD=CXX11` only on R < 4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     later (>= 0.8.0)
 LinkingTo: Rcpp, later
 URL: https://github.com/rstudio/httpuv
-SystemRequirements: GNU make, C++11, zlib
+SystemRequirements: GNU make, zlib
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 Suggests:

--- a/src/Makevars
+++ b/src/Makevars
@@ -2,7 +2,7 @@
 # Versions of R 4.0 and above always have C++11.
 # Versions of R 4.3 and above will complain if CXX_STD is set to CXX11.
 # To satisfy all these versions, we'll set CXX_STD=CXX11 only when R < 4.0.
-R_VERSION=$(shell $(R_HOME)/bin/Rscript --vanilla -e 'if (getRversion()<4) cat("lt4") else cat("ge4")')
+R_VERSION=$(shell $(R_HOME)/binn$(R_ARCH_BIN)/Rscript --vanilla -e 'if (getRversion()<4) cat("lt4") else cat("ge4")')
 ifeq ($(R_VERSION), lt4)
 CXX_STD=CXX11
 endif

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,7 +1,11 @@
-## Use the R_HOME indirection to support installations of multiple R version
-
-# Use C++11 if available
+# On R prior to 4.0, specify C++11.
+# Versions of R 4.0 and above always have C++11.
+# Versions of R 4.3 and above will complain if CXX_STD is set to CXX11.
+# To satisfy all these versions, we'll set CXX_STD=CXX11 only when R < 4.0.
+R_VERSION=$(shell $(R_HOME)/bin/Rscript --vanilla -e 'if (getRversion()<4) cat("lt4") else cat("ge4")')
+ifeq ($(R_VERSION), lt4)
 CXX_STD=CXX11
+endif
 
 UNAME := $(shell uname)
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,11 @@
-# Use C++11 if available
+# On R prior to 4.0, specify C++11.
+# Versions of R 4.0 and above always have C++11.
+# Versions of R 4.3 and above will complain if CXX_STD is set to CXX11.
+# To satisfy all these versions, we'll set CXX_STD=CXX11 only when R < 4.0.
+R_VERSION=$(shell $(R_HOME)/bin/Rscript --vanilla -e 'if (getRversion()<4) cat("lt4") else cat("ge4")')
+ifeq ($(R_VERSION), lt4)
 CXX_STD=CXX11
+endif
 
 PKG_LIBS = ./libuv/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o \
 	-lpthread -lws2_32 -lkernel32 -lpsapi -liphlpapi -lshell32 -luserenv -lz

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -2,7 +2,7 @@
 # Versions of R 4.0 and above always have C++11.
 # Versions of R 4.3 and above will complain if CXX_STD is set to CXX11.
 # To satisfy all these versions, we'll set CXX_STD=CXX11 only when R < 4.0.
-R_VERSION=$(shell $(R_HOME)/bin/Rscript --vanilla -e 'if (getRversion()<4) cat("lt4") else cat("ge4")')
+R_VERSION=$(shell $(R_HOME)/bin$(R_ARCH_BIN)/Rscript --vanilla -e 'if (getRversion()<4) cat("lt4") else cat("ge4")')
 ifeq ($(R_VERSION), lt4)
 CXX_STD=CXX11
 endif


### PR DESCRIPTION
This is needed because the current version of R-devel complains if C++11 is specified. See discussion thread here for more information:
https://stat.ethz.ch/pipermail/r-package-devel/2023q1/008870.html

Note that the changes to Makevars are possible because the DESCRIPTION file has `SystemRequirements: GNU make`. Other versions of `make` will not be able to do the conditional variable setting, and so packages that don't specify GNU make will probably need a `configure` script.