### PR TITLE
Remove `CXX_STD`

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,12 +1,3 @@
-# On R prior to 4.0, specify C++11.
-# Versions of R 4.0 and above always have C++11.
-# Versions of R 4.3 and above will complain if CXX_STD is set to CXX11.
-# To satisfy all these versions, we'll set CXX_STD=CXX11 only when R < 4.0.
-R_VERSION=$(shell $(R_HOME)/bin$(R_ARCH_BIN)/Rscript --vanilla -e 'if (getRversion()<4) cat("lt4") else cat("ge4")')
-ifeq ($(R_VERSION), lt4)
-CXX_STD=CXX11
-endif
-
 UNAME := $(shell uname)
 
 PKG_LIBS = ./libuv/.libs/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o -pthread

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,12 +1,3 @@
-# On R prior to 4.0, specify C++11.
-# Versions of R 4.0 and above always have C++11.
-# Versions of R 4.3 and above will complain if CXX_STD is set to CXX11.
-# To satisfy all these versions, we'll set CXX_STD=CXX11 only when R < 4.0.
-R_VERSION=$(shell $(R_HOME)/bin$(R_ARCH_BIN)/Rscript --vanilla -e 'if (getRversion()<4) cat("lt4") else cat("ge4")')
-ifeq ($(R_VERSION), lt4)
-CXX_STD=CXX11
-endif
-
 PKG_LIBS = ./libuv/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o \
 	-lpthread -lws2_32 -lkernel32 -lpsapi -liphlpapi -lshell32 -luserenv -lz
 


### PR DESCRIPTION
The "fix" in #356 did not fix the issue of R-devel raising a NOTE. For more information, see https://github.com/astamm/nloptr/issues/130#issuecomment-1422671905

This change should fix it, but it will also make it so that httpuv might not compile on R 3.5 (if the system has an old compiler), unless the user sets `CXX_STD` in their user-level `~/.R/Makevars` file.

For more information:
https://gist.github.com/wch/849ca79c9416795d99c48cc06a44ca1e