### PR TITLE
Send WS ping frames every 20 seconds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # httpuv 1.6.9.9000
 
-* WebSocket connections now send Ping frames to the client every 20 seconds. This is only intended to serve as a keepalive for proxies that might be sitting in front of us; we don't pay attention to whether a Pong response is received in a timely manner.
+* WebSocket connections now send Ping frames to the client every 20 seconds. This is only intended to serve as a keepalive for proxies that might be sitting in front of us; we don't pay attention to whether a Pong response is received in a timely manner. (#359)
 
 
 # httpuv 1.6.9

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httpuv 1.6.9.9000
 
+* WebSocket connections now send Ping frames to the client every 20 seconds. This is only intended to serve as a keepalive for proxies that might be sitting in front of us; we don't pay attention to whether a Pong response is received in a timely manner.
+
 
 # httpuv 1.6.9
 

--- a/src/httprequest.h
+++ b/src/httprequest.h
@@ -205,7 +205,7 @@ public:
     );
 
     _pWebSocketConnection = std::shared_ptr<WebSocketConnection>(
-      new WebSocketConnection(this_base),
+      new WebSocketConnection(this->_pLoop, this_base),
       auto_deleter_background<WebSocketConnection>
     );
 

--- a/src/websockets.cpp
+++ b/src/websockets.cpp
@@ -221,6 +221,8 @@ void WSHyBiParser::read(const char* data, size_t len) {
 }
 
 void WebSocketConnection::startPingTimer() {
+  ASSERT_BACKGROUND_THREAD()
+
   uv_timer_start(&_pingTimer, pingTimerCallback, 20000, 20000);
 }
 


### PR DESCRIPTION
- [x] Add NEWS
- [x] Manual testing
- [ ] Automated test?

## Manual testing performed

I used this build of httpuv with Shiny, both locally and deployed over Hugging Face Spaces, using Wireshark to make sure that Ping packets were being sent at the correct intervals.

I also used this torture test app:

```r
library(httpuv)

big_string <- strrep("j", 1e6)

app <- list(
  onWSOpen = function(conn) {
    stopped <- FALSE
    conn$onClose(function() {
      stopped <<- TRUE
    })


    cb <- function(...) {
      if (stopped) {
        return()
      }
      message("sending")
      conn$send(big_string)
    }
    cb()

    conn$onMessage(cb)
  }
)

httpuv::runServer("0.0.0.0", 8101, app)
```

In the browser on another machine, I navigated to `about:blank` and typed this code into the JS console:
```javascript
var ws = new WebSocket("ws://<HOSTNAME>:8101");
ws.onmessage = (msg) => {
  if (!/^j+$/.test(msg.data)) {
    console.log("bad");
  } else {
    console.log("good");
  }
  ws.send("");
};
```
What this does is repeatedly send large (1MB) messages from server to client, way too big to fit in a single TCP packet. I wanted to ensure that the Ping packets being sent at random times wouldn't get in between packets belonging to a message. The test worked; even hacking the httpuv source code to send Ping every 10 milliseconds didn't pose a problem.