### PR TITLE
Use system copy of libuv if found

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -6,7 +6,6 @@ on:
   push:
     branches: [main, rc-**]
   pull_request:
-    branches: [main]
   schedule:
     - cron: '0 6 * * 1' # every monday
 

--- a/.github/workflows/system-libuv.yaml
+++ b/.github/workflows/system-libuv.yaml
@@ -1,0 +1,79 @@
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, rc-**]
+  pull_request:
+  schedule:
+    - cron: '0 6 * * 1' # every monday
+
+name: Test system libuv
+
+jobs:
+  R-CMD-check:
+    # Ubuntu 22.04 has libuv1-dev version 1.43, which is sufficient
+    runs-on: ubuntu-latest
+    name: Installed=${{ matrix.config.install }} Bundled=${{ matrix.config.use }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # This one should test that we've used system and everything runs ok
+          - {install: true}
+          # This one should test for bundling log message
+          - {install: true, use: true}
+          # This one should test for failure
+          - {install: false, use: false}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - name: Install libuv
+        if: ${{ matrix.config.install }}
+        # If we add tests for e.g. rhel/centos, we couldn't assume apt-get
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libuv1-dev
+
+      - name: Ensure libuv is not on the system
+        if: ${{ !matrix.config.install }}
+        run: |
+          sudo apt-get remove -y libuv1-dev || true
+                   
+      - uses: r-lib/actions/check-r-package@v2
+        if: ${{ matrix.config.install }}
+        env:
+          USE_BUNDLED_LIBUV: ${{ matrix.config.use }}
+        with:
+          upload-snapshots: true
+      
+      - name: Confirm that USE_BUNDLED_LIBUV was respected
+        if: ${{ matrix.config.install }}
+        env:
+          USE_BUNDLED_LIBUV: ${{ matrix.config.use }}
+        run: |
+          if [ "$USE_BUNDLED_LIBUV" = "true" ]; then
+            grep "Using bundled copy of libuv" check/httpuv.Rcheck/00install.out
+          else
+            grep "Using libuv found by pkg-config" check/httpuv.Rcheck/00install.out
+          fi
+
+      - name: Confirm error if system libuv missing and use=false
+        if: ${{ !matrix.config.install && !matrix.config.use }}
+        env:
+          USE_BUNDLED_LIBUV: ${{ matrix.config.use }}
+        run: |
+          R CMD INSTALL . > install.log || true
+          grep "Did not find suitable libuv on your system" install.log

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ CRAN-RELEASE
 httpuv_*.tar.gz
 src/Makevars
 configure.log
+.vscode
+*.orig

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ src/httpuv.includes
 .Rproj.user
 CRAN-RELEASE
 httpuv_*.tar.gz
+src/Makevars
+configure.log

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ remotes::install_github("rstudio/httpuv")
 
 Since httpuv contains C code, you'll need to make sure you're set up to install packages with compiled code. Follow the instructions at http://www.rstudio.com/ide/docs/packages/prerequisites
 
+httpuv may optionally be built using a `libuv` system package, which you can install prior to installing the R package. It goes by different names on different package managers: `libuv1-dev` (deb), `libuv-devel` (rpm), `libuv` (brew). Version 1.43 or greater is required. If `libuv` is not found on the system, it will be built from source along with the R package.
 
 ## Basic Usage
 

--- a/cleanup
+++ b/cleanup
@@ -1,0 +1,2 @@
+#!/bin/sh
+rm -f src/Makevars configure.log

--- a/cleanup
+++ b/cleanup
@@ -1,2 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
+
 rm -f src/Makevars configure.log

--- a/configure
+++ b/configure
@@ -1,0 +1,82 @@
+# Anticonf (tm) script by Jeroen Ooms (2021)
+# This script will query 'pkg-config' for the required cflags and ldflags.
+# If pkg-config is unavailable or does not find the library, try setting
+# INCLUDE_DIR and LIB_DIR manually via e.g:
+# R CMD INSTALL --configure-vars='INCLUDE_DIR=/.../include LIB_DIR=/.../lib'
+
+# Library settings
+PKG_CONFIG_NAME="libuv"
+PKG_DEB_NAME="libuv1-dev"
+PKG_RPM_NAME="libuv-devel"
+# PKG_CSW_NAME="libsodium_dev"
+PKG_BREW_NAME="libuv"
+PKG_TEST_HEADER="<uv.h>"
+PKG_LIBS="-luv"
+PKG_CFLAGS=""
+DEPS=""
+
+# Use pkg-config if available
+if [ `command -v pkg-config` ]; then
+  PKGCONFIG_CFLAGS=`pkg-config --cflags --silence-errors ${PKG_CONFIG_NAME}`
+  PKGCONFIG_LIBS=`pkg-config --libs ${PKG_CONFIG_NAME}`
+fi
+
+# Note that cflags may be empty in case of success
+if [ "$INCLUDE_DIR" ] || [ "$LIB_DIR" ]; then
+  echo "Found INCLUDE_DIR and/or LIB_DIR!"
+  PKG_CFLAGS="-I$INCLUDE_DIR $PKG_CFLAGS"
+  PKG_LIBS="-L$LIB_DIR $PKG_LIBS"
+elif [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
+  echo "Found pkg-config cflags and libs!"
+  PKG_CFLAGS=${PKGCONFIG_CFLAGS}
+  PKG_LIBS=${PKGCONFIG_LIBS}
+elif [ `uname` = "Darwin" ]; then
+  test ! "$CI" && brew --version 2>/dev/null
+  if [ $? -eq 0 ]; then
+    BREWDIR=`brew --prefix`
+    PKG_CFLAGS="-I$BREWDIR/include"
+    PKG_LIBS="-L$BREWDIR/lib $PKG_LIBS"
+  fi
+fi
+
+# For debugging
+echo "Using PKG_CFLAGS=$PKG_CFLAGS"
+echo "Using PKG_LIBS=$PKG_LIBS"
+
+# Find compiler
+CC=`${R_HOME}/bin/R CMD config CC`
+CFLAGS=`${R_HOME}/bin/R CMD config CFLAGS`
+CPPFLAGS=`${R_HOME}/bin/R CMD config CPPFLAGS`
+
+# Test configuration
+echo "#include $PKG_TEST_HEADER" | ${CC} ${CPPFLAGS} ${PKG_CFLAGS} ${CFLAGS} -E -xc - >/dev/null 2>configure.log
+
+# Customize the error
+if [ $? -ne 0 ]; then
+  echo "--------------------------- [ANTICONF] --------------------------------"
+  echo "Didn't find $PKG_CONFIG_NAME on your system, so we'll use a copy that we bundle"
+  echo "with httpuv. If you would prefer to use a system copy, try installing:"
+  echo " * deb: $PKG_DEB_NAME (Debian, Ubuntu, etc)"
+  echo " * rpm: $PKG_RPM_NAME (Fedora, EPEL)"
+  # echo " * csw: $PKG_CSW_NAME (Solaris)"
+  echo " * brew: $PKG_BREW_NAME (OSX)"
+  echo "If $PKG_CONFIG_NAME is already installed, check that 'pkg-config' is in your"
+  echo "PATH and PKG_CONFIG_PATH contains a $PKG_CONFIG_NAME.pc file. If pkg-config"
+  echo "is unavailable you can set INCLUDE_DIR and LIB_DIR manually via:"
+  echo "R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'"
+  echo "-------------------------- [ERROR MESSAGE] ---------------------------"
+  cat configure.log
+  echo "----------------------------------------------------------------------"
+  echo "Continuing with bundled copy of libuv."
+  # Use bundled libuv:
+  #
+  PKG_CFLAGS="-Ilibuv/include"
+  PKG_LIBS="./libuv/.libs/libuv.a"
+  DEPS="libuv/.libs/libuv.a"
+fi
+
+# Write to Makevars
+sed -e "s|@cflags@|$PKG_CFLAGS|" -e "s|@libs@|$PKG_LIBS|" -e "s|@deps@|$DEPS|" src/Makevars.in > src/Makevars
+
+# Success
+exit 0

--- a/configure
+++ b/configure
@@ -1,80 +1,85 @@
-# Anticonf (tm) script by Jeroen Ooms (2021)
-# This script will query 'pkg-config' for the required cflags and ldflags.
-# If pkg-config is unavailable or does not find the library, try setting
-# INCLUDE_DIR and LIB_DIR manually via e.g:
-# R CMD INSTALL --configure-vars='INCLUDE_DIR=/.../include LIB_DIR=/.../lib'
+# Derived from: Anticonf (tm) script by Jeroen Ooms (2021)
 
 # Library settings
 PKG_CONFIG_NAME="libuv"
 PKG_DEB_NAME="libuv1-dev"
 PKG_RPM_NAME="libuv-devel"
-# PKG_CSW_NAME="libsodium_dev"
 PKG_BREW_NAME="libuv"
-PKG_TEST_HEADER="<uv.h>"
 PKG_LIBS="-luv"
 PKG_CFLAGS=""
 DEPS=""
 
-# Use pkg-config if available
-if [ `command -v pkg-config` ]; then
-  PKGCONFIG_CFLAGS=`pkg-config --cflags --silence-errors ${PKG_CONFIG_NAME}`
-  PKGCONFIG_LIBS=`pkg-config --libs ${PKG_CONFIG_NAME}`
-fi
+# For messaging; if changing this, be sure also to set UV_VERSION_HEX check 
+MINIMUM_LIBUV_VERSION="1.43"
 
-# Note that cflags may be empty in case of success
-if [ "$INCLUDE_DIR" ] || [ "$LIB_DIR" ]; then
-  echo "Found INCLUDE_DIR and/or LIB_DIR!"
-  PKG_CFLAGS="-I$INCLUDE_DIR $PKG_CFLAGS"
-  PKG_LIBS="-L$LIB_DIR $PKG_LIBS"
-elif [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
-  echo "Found pkg-config cflags and libs!"
-  PKG_CFLAGS=${PKGCONFIG_CFLAGS}
-  PKG_LIBS=${PKGCONFIG_LIBS}
-elif [ `uname` = "Darwin" ]; then
-  test ! "$CI" && brew --version 2>/dev/null
-  if [ $? -eq 0 ]; then
-    BREWDIR=`brew --prefix`
+# If unset (default), will try to find libuv on system and fall back to bundled
+# If true (case insensitive), will not look for system library
+# If false, will not fall back to bundled if system library not found
+USE_BUNDLED_LIBUV=`echo $USE_BUNDLED_LIBUV | tr '[:upper:]' '[:lower:]'`
+
+
+if [ "${USE_BUNDLED_LIBUV}" != "true" ]; then
+  # First, look for libuv installed on the system (pkg-config, then brew)
+  if pkg-config ${PKG_CONFIG_NAME} 2>&1; then
+    echo "** Using libuv found by pkg-config in `pkg-config --variable=prefix --silence-errors ${PKG_CONFIG_NAME}`"
+    PKG_CFLAGS=`pkg-config --cflags --silence-errors ${PKG_CONFIG_NAME}`
+    PKG_LIBS=`pkg-config --libs ${PKG_CONFIG_NAME}`
+    LIBUV_FOUND="true"
+  elif brew --prefix ${PKG_BREW_NAME} > /dev/null 2>&1; then
+    BREWDIR=`brew --prefix ${PKG_BREW_NAME}`
+    echo "** Using Homebrew libuv in ${BREWDIR}"
     PKG_CFLAGS="-I$BREWDIR/include"
     PKG_LIBS="-L$BREWDIR/lib $PKG_LIBS"
+    LIBUV_FOUND="true"
+  fi
+
+  # If found, check that its version is recent enough
+  if [ "${LIBUV_FOUND}" = "true" ]; then
+    # Find compiler
+    CC=`${R_HOME}/bin/R CMD config CC`
+    CFLAGS=`${R_HOME}/bin/R CMD config CFLAGS`
+    CPPFLAGS=`${R_HOME}/bin/R CMD config CPPFLAGS`
+
+    # Test whether libuv really is there and is the right version
+    # Minor versions only add backwards-compatible changes, but
+    # major versions may break, so assert 1.43 <= v < 2
+    # See libuv/docs/src/version.rst about UV_VERSION_HEX
+    # 1.43 -> 01 2B in hex
+    echo "
+    #include <uv.h>
+    #if UV_VERSION_HEX < 0x012B00L
+    #error libuv version too old: >= ${MINIMUM_LIBUV_VERSION} required
+    #endif
+    #if UV_MAJOR_VERSION > 1
+    #error libuv version too new (1.x required)
+    #endif" | ${CC} ${CPPFLAGS} ${PKG_CFLAGS} ${CFLAGS} -E -xc - >/dev/null 2>configure.log
+    if [ $? -ne 0 ]; then
+      echo "** Found libuv is not suitable"
+      cat configure.log
+      unset LIBUV_FOUND
+    fi
+  fi
+fi
+
+# If libuv not found, use the bundled copy (unless USE_BUNDLED_LIBUV=false)
+if [ "${LIBUV_FOUND}" != "true" ]; then
+  if [ "${USE_BUNDLED_LIBUV}" = "false" ]; then
+    echo "** Did not find suitable libuv on your system,"
+    echo "** and not building from source because USE_BUNDLED_LIBUV=false."
+    echo "** Please install libuv >= ${MINIMUM_LIBUV_VERSION} or unset USE_BUNDLED_LIBUV"
+    exit 1
+  else
+    echo "** Using bundled copy of libuv"
+    PKG_CFLAGS="-Ilibuv/include"
+    PKG_LIBS="./libuv/.libs/libuv.a"
+    # By setting DEPS, this triggers the libuv build in src/Makevars
+    DEPS="libuv/.libs/libuv.a"
   fi
 fi
 
 # For debugging
 echo "Using PKG_CFLAGS=$PKG_CFLAGS"
 echo "Using PKG_LIBS=$PKG_LIBS"
-
-# Find compiler
-CC=`${R_HOME}/bin/R CMD config CC`
-CFLAGS=`${R_HOME}/bin/R CMD config CFLAGS`
-CPPFLAGS=`${R_HOME}/bin/R CMD config CPPFLAGS`
-
-# Test configuration
-echo "#include $PKG_TEST_HEADER" | ${CC} ${CPPFLAGS} ${PKG_CFLAGS} ${CFLAGS} -E -xc - >/dev/null 2>configure.log
-
-# Customize the error
-if [ $? -ne 0 ]; then
-  echo "--------------------------- [ANTICONF] --------------------------------"
-  echo "Didn't find $PKG_CONFIG_NAME on your system, so we'll use a copy that we bundle"
-  echo "with httpuv. If you would prefer to use a system copy, try installing:"
-  echo " * deb: $PKG_DEB_NAME (Debian, Ubuntu, etc)"
-  echo " * rpm: $PKG_RPM_NAME (Fedora, EPEL)"
-  # echo " * csw: $PKG_CSW_NAME (Solaris)"
-  echo " * brew: $PKG_BREW_NAME (OSX)"
-  echo "If $PKG_CONFIG_NAME is already installed, check that 'pkg-config' is in your"
-  echo "PATH and PKG_CONFIG_PATH contains a $PKG_CONFIG_NAME.pc file. If pkg-config"
-  echo "is unavailable you can set INCLUDE_DIR and LIB_DIR manually via:"
-  echo "R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'"
-  echo "-------------------------- [ERROR MESSAGE] ---------------------------"
-  cat configure.log
-  echo "----------------------------------------------------------------------"
-  echo "Continuing with bundled copy of libuv."
-  # Use bundled libuv:
-  #
-  PKG_CFLAGS="-Ilibuv/include"
-  PKG_LIBS="./libuv/.libs/libuv.a"
-  DEPS="libuv/.libs/libuv.a"
-fi
-
 # Write to Makevars
 sed -e "s|@cflags@|$PKG_CFLAGS|" -e "s|@libs@|$PKG_LIBS|" -e "s|@deps@|$DEPS|" src/Makevars.in > src/Makevars
 

--- a/configure
+++ b/configure
@@ -1,85 +1,43 @@
-# Derived from: Anticonf (tm) script by Jeroen Ooms (2021)
+#!/usr/bin/env sh
 
-# Library settings
 PKG_CONFIG_NAME="libuv"
-PKG_DEB_NAME="libuv1-dev"
-PKG_RPM_NAME="libuv-devel"
-PKG_BREW_NAME="libuv"
-PKG_LIBS="-luv"
-PKG_CFLAGS=""
-DEPS=""
-
-# For messaging; if changing this, be sure also to set UV_VERSION_HEX check 
-MINIMUM_LIBUV_VERSION="1.43"
+LIBUV_VERSION_REQUIRED="$PKG_CONFIG_NAME >= 1.43 $PKG_CONFIG_NAME < 2"
 
 # If unset (default), will try to find libuv on system and fall back to bundled
 # If true (case insensitive), will not look for system library
 # If false, will not fall back to bundled if system library not found
 USE_BUNDLED_LIBUV=`echo $USE_BUNDLED_LIBUV | tr '[:upper:]' '[:lower:]'`
 
-
-if [ "${USE_BUNDLED_LIBUV}" != "true" ]; then
-  # First, look for libuv installed on the system (pkg-config, then brew)
-  if pkg-config ${PKG_CONFIG_NAME} 2>&1; then
-    echo "** Using libuv found by pkg-config in `pkg-config --variable=prefix --silence-errors ${PKG_CONFIG_NAME}`"
-    PKG_CFLAGS=`pkg-config --cflags --silence-errors ${PKG_CONFIG_NAME}`
-    PKG_LIBS=`pkg-config --libs ${PKG_CONFIG_NAME}`
-    LIBUV_FOUND="true"
-  elif brew --prefix ${PKG_BREW_NAME} > /dev/null 2>&1; then
-    BREWDIR=`brew --prefix ${PKG_BREW_NAME}`
-    echo "** Using Homebrew libuv in ${BREWDIR}"
-    PKG_CFLAGS="-I$BREWDIR/include"
-    PKG_LIBS="-L$BREWDIR/lib $PKG_LIBS"
-    LIBUV_FOUND="true"
-  fi
-
-  # If found, check that its version is recent enough
-  if [ "${LIBUV_FOUND}" = "true" ]; then
-    # Find compiler
-    CC=`${R_HOME}/bin/R CMD config CC`
-    CFLAGS=`${R_HOME}/bin/R CMD config CFLAGS`
-    CPPFLAGS=`${R_HOME}/bin/R CMD config CPPFLAGS`
-
-    # Test whether libuv really is there and is the right version
-    # Minor versions only add backwards-compatible changes, but
-    # major versions may break, so assert 1.43 <= v < 2
-    # See libuv/docs/src/version.rst about UV_VERSION_HEX
-    # 1.43 -> 01 2B in hex
-    echo "
-    #include <uv.h>
-    #if UV_VERSION_HEX < 0x012B00L
-    #error libuv version too old: >= ${MINIMUM_LIBUV_VERSION} required
-    #endif
-    #if UV_MAJOR_VERSION > 1
-    #error libuv version too new (1.x required)
-    #endif" | ${CC} ${CPPFLAGS} ${PKG_CFLAGS} ${CFLAGS} -E -xc - >/dev/null 2>configure.log
-    if [ $? -ne 0 ]; then
-      echo "** Found libuv is not suitable"
-      cat configure.log
-      unset LIBUV_FOUND
-    fi
-  fi
+if [ `uname -s` = "Darwin" ]; then
+  # Always do static linking on macOS
+  PKG_CONFIG="pkg-config --static"
+else
+  PKG_CONFIG="pkg-config"
 fi
 
-# If libuv not found, use the bundled copy (unless USE_BUNDLED_LIBUV=false)
-if [ "${LIBUV_FOUND}" != "true" ]; then
-  if [ "${USE_BUNDLED_LIBUV}" = "false" ]; then
-    echo "** Did not find suitable libuv on your system,"
-    echo "** and not building from source because USE_BUNDLED_LIBUV=false."
-    echo "** Please install libuv >= ${MINIMUM_LIBUV_VERSION} or unset USE_BUNDLED_LIBUV"
-    exit 1
-  else
-    echo "** Using bundled copy of libuv"
-    PKG_CFLAGS="-Ilibuv/include"
-    PKG_LIBS="./libuv/.libs/libuv.a"
-    # By setting DEPS, this triggers the libuv build in src/Makevars
-    DEPS="libuv/.libs/libuv.a"
-  fi
+# First, look for suitable libuv installed on the system 
+if [ "${USE_BUNDLED_LIBUV}" != "true" ] && ${PKG_CONFIG} --exists ''"${LIBUV_VERSION_REQUIRED}"'' 2>&1; then
+  echo "** Using libuv found by pkg-config in `${PKG_CONFIG} --variable=prefix --silence-errors ${PKG_CONFIG_NAME}`"
+  PKG_CFLAGS=`${PKG_CONFIG} --cflags --silence-errors ${PKG_CONFIG_NAME}`
+  PKG_LIBS=`${PKG_CONFIG} --libs ${PKG_CONFIG_NAME}`
+  DEPS=""
+elif [ "${USE_BUNDLED_LIBUV}" != "false" ]; then
+  # If not found, use the bundled copy (unless directed otherwise)
+  echo "** Using bundled copy of libuv"
+  PKG_CFLAGS="-Ilibuv/include"
+  PKG_LIBS="./libuv/.libs/libuv.a"
+  # By setting DEPS, this triggers the libuv build in src/Makevars
+  DEPS="libuv/.libs/libuv.a"
+else
+  echo "** Did not find suitable libuv on your system,"
+  echo "** and not building from source because USE_BUNDLED_LIBUV=false."
+  echo "** Please install ${LIBUV_VERSION_REQUIRED} or unset USE_BUNDLED_LIBUV"
+  exit 1
 fi
 
 # For debugging
-echo "Using PKG_CFLAGS=$PKG_CFLAGS"
-echo "Using PKG_LIBS=$PKG_LIBS"
+echo "** PKG_CFLAGS=$PKG_CFLAGS"
+echo "** PKG_LIBS=$PKG_LIBS"
 # Write to Makevars
 sed -e "s|@cflags@|$PKG_CFLAGS|" -e "s|@libs@|$PKG_LIBS|" -e "s|@deps@|$DEPS|" src/Makevars.in > src/Makevars
 

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,6 +1,6 @@
 UNAME := $(shell uname)
 
-PKG_LIBS = ./libuv/.libs/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o -pthread
+PKG_LIBS = @libs@ ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o -pthread
 
 ifeq ($(UNAME), Darwin)
 PKG_LIBS += -framework CoreServices
@@ -18,7 +18,7 @@ endif
 
 PKG_CFLAGS = $(C_VISIBILITY) -DSTRICT_R_HEADERS
 PKG_CXXFLAGS = $(CXX_VISIBILITY) -DSTRICT_R_HEADERS
-PKG_CPPFLAGS = -Ilibuv/include -pthread
+PKG_CPPFLAGS = @cflags@ -pthread
 
 # To avoid spurious warnings from `R CMD check --as-cran`, about compiler
 # warning flags like -Werror.
@@ -38,7 +38,7 @@ CONFIGURE_FLAGS="--quiet"
 # PKG_CPPFLAGS += -D_GLIBCXX_ASSERTIONS
 
 
-$(SHLIB): libuv/.libs/libuv.a http-parser/http_parser.o sha1/sha1.o base64/base64.o
+$(SHLIB): @deps@ http-parser/http_parser.o sha1/sha1.o base64/base64.o
 
 # We needed to rename lt~obsolete.m4 because the name causes problems with R
 # CMD check. Here we rename it back.


### PR DESCRIPTION
Adds a configure script that looks for libuv on the system that is version 1.43 (what we bundle) or newer. On macOS, static linking is preferred. If the library isn't found, installation falls backed to the bundled copy, as before. There is a new environment variable, `USE_BUNDLED_LIBUV`, that can be set to override this behavior: `true` means it won't look for system libuv, `false` means it won't build the bundled library and will fail if the system library isn't found.

Homebrew and Ubuntu 22.04 have new enough versions of libuv that could be installed. Our regular CI picks up the brew package in the macos-latest job, and I added a new workflow that tests the ubuntu package and the various combinations of the `USE_BUNDLED_LIBUV` variable.