### PR TITLE
Add -DNDEBUG to libuv build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,7 +3,7 @@
 /\.mailmap$
 /\.readthedocs.yaml$
 /\.git$
-/\.o$
+\.o$
 /\.so$
 /\.dll$
 ^src/README.md$

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ src/httpuv.files
 src/httpuv.includes
 .Rproj.user
 CRAN-RELEASE
+httpuv_*.tar.gz

--- a/src/Makevars
+++ b/src/Makevars
@@ -77,7 +77,7 @@ libuv/Makefile: libuv/m4/lt~obsolete.m4
 		sh autogen.sh; \
 	fi; \
 	chmod +x configure; \
-	CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(C_VISIBILITY)" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure $(CONFIGURE_FLAGS)
+	CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(C_VISIBILITY) -DNDEBUG" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure $(CONFIGURE_FLAGS)
 
 libuv/.libs/libuv.a: libuv/Makefile
 	$(MAKE) --directory=libuv \

--- a/src/Makevars
+++ b/src/Makevars
@@ -77,7 +77,7 @@ libuv/Makefile: libuv/m4/lt~obsolete.m4
 		sh autogen.sh; \
 	fi; \
 	chmod +x configure; \
-	CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(C_VISIBILITY) -DNDEBUG" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure $(CONFIGURE_FLAGS)
+	CC="$(CC)" CFLAGS="$(CFLAGS) $(CPPFLAGS) $(CPICFLAGS) $(C_VISIBILITY) -DNDEBUG" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure $(CONFIGURE_FLAGS)
 
 libuv/.libs/libuv.a: libuv/Makefile
 	$(MAKE) --directory=libuv \

--- a/src/Makevars
+++ b/src/Makevars
@@ -77,7 +77,7 @@ libuv/Makefile: libuv/m4/lt~obsolete.m4
 		sh autogen.sh; \
 	fi; \
 	chmod +x configure; \
-	CC="$(CC)" CFLAGS="$(CFLAGS) $(CPPFLAGS) $(CPICFLAGS) $(C_VISIBILITY) -DNDEBUG" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure $(CONFIGURE_FLAGS)
+	CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(C_VISIBILITY) -DNDEBUG" CPPFLAGS="$(CPPFLAGS)" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure $(CONFIGURE_FLAGS)
 
 libuv/.libs/libuv.a: libuv/Makefile
 	$(MAKE) --directory=libuv \


### PR DESCRIPTION
I can confirm this is working because I now see in the libuv build: 

```
src/unix/darwin.c:214:17: warning: variable 'kr' set but not used [-Wunused-but-set-variable]
  kern_return_t kr;
                ^
```

AFAICT `kr` is only used in `assert()` statements that NDEBUG removes. This appears not to have an affect on the `R CMD check` results.