### PR TITLE
Fix strict linking on MacOS

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -3,7 +3,7 @@ UNAME := $(shell uname)
 PKG_LIBS = @libs@ ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o -pthread
 
 ifeq ($(UNAME), Darwin)
-PKG_LIBS += -framework CoreServices
+PKG_LIBS += -lz -framework CoreServices
 endif
 
 ifeq ($(UNAME), SunOS)


### PR DESCRIPTION
When we cross compile for MacOS we see a linking error:

```
 /osxcross/bin/o64-clang++ -arch x86_64 -std=gnu++17 -mmacosx-version-min=11.0 -dynamiclib -Wl,-headerpad_max_install_names -single_module -multiply_defined suppress -fuse-ld=/osxcross/bin/x86_64-apple-darwin22.2-ld -L/macos/r/lib -L/opt/R/x86_64/lib -o httpuv.so RcppExports.o callback.o callbackqueue.o filedatasource-unix.o filedatasource-win.o fs.o gzipdatasource.o http.o httprequest.o httpresponse.o httpuv.o md5.o mime.o socket.o staticpath.o thread.o timegm.o utils.o uvutil.o webapplication.o websockets-base.o websockets-hixie76.o websockets-hybi03.o websockets-ietf.o websockets.o winutils.o -L/tmp/macosSLs -L/tmp/macosDLs -L/macos/usr/lib ./libuv/.libs/libuv.a ./http-parser/http_parser.o ./sha1/sha1.o ./base64/base64.o -pthread -framework CoreServices -L/macos/r/lib -lR -Wl,-framework -Wl,CoreFoundation
  Undefined symbols for architecture x86_64:
    "_deflate", referenced from:
        GZipDataSource::getData(unsigned long) in gzipdatasource.o
        GZipDataSource::deflateNext() in gzipdatasource.o
    "_deflateEnd", referenced from:
        GZipDataSource::~GZipDataSource() in gzipdatasource.o
    "_deflateInit2_", referenced from:
        GZipDataSource::GZipDataSource(std::__1::shared_ptr<DataSource>) in gzipdatasource.o
  ld: symbol(s) not found for architecture x86_64
  clang: error: linker command failed with exit code 1 (use -v to see invocation)
  make: *** [/usr/share/R/share/make/shlib.mk:10: httpuv.so] Error 1
```

This happens because the package calls libz but is not properly linking to it.

The reason that this is not surfacing earlier is that R happens to pre-load zlib (as part of libcurl) and R on MacOS defaults to ignoring linking errors by passing `-undefined dynamic_lookup`.