### PR TITLE
Fix R CMD check warning re error() format strings (for r-devel)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httpuv (development version)
 
+* Closed #388: Fix R CMD check warning re error() format strings (for r-devel). (#389)
+
 # httpuv 1.6.12
 
 * New `runStaticServer()` provides a convenient interface for serving a directory of static files. (#380)

--- a/src/webapplication.cpp
+++ b/src/webapplication.cpp
@@ -220,7 +220,7 @@ std::shared_ptr<HttpResponse> listToResponse(
       Rcpp::as<bool>(response["bodyFileOwned"])
     );
     if (ret != FDS_OK) {
-      REprintf(pFDS->lastErrorMessage().c_str());
+      REprintf("%s", pFDS->lastErrorMessage().c_str());
       return error_response(pRequest, 500);
     }
     pDataSource = pFDS;


### PR DESCRIPTION
Closes #388