### PR TITLE
Increment version number to 1.6.14.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: httpuv
 Title: HTTP and WebSocket Server Library
-Version: 1.6.14
+Version: 1.6.14.9000
 Authors@R: c(
     person("Joe", "Cheng", , "joe@posit.co", role = "aut"),
     person("Winston", "Chang", , "winston@posit.co", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# httpuv (development version)
+
 # httpuv 1.6.14
 
 * Updated Makevars.ucrt for upcoming release of Rtools (thanks to Tomas Kalibera).


### PR DESCRIPTION
Part of our typical post-release process is to call `usethis::use_dev_version()`, to bump the GitHub version of the package up to the dev version and add the appropriate heading in the NEWS.

There are two primary advantages to this:

1. It makes it immediately clear via `packageVersion()` if the package was installed from GitHub.
1. The next PR to the package doesn't need to do this boilerplate update.

I'll also make releases for the last two released versions.