### PR TITLE
fix(runStaticServer): Don't fail when trying to open browser

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httpuv (development version)
 
+* `runStaticServer()` no longer fails if `browse = TRUE` but `utils::browseURL()` is unable to open the server. (#395)
+
 # httpuv 1.6.14
 
 * Updated Makevars.ucrt for upcoming release of Rtools (thanks to Tomas Kalibera).

--- a/R/staticServer.R
+++ b/R/staticServer.R
@@ -72,7 +72,7 @@ runStaticServer <- function(
     tryCatch(
       utils::browseURL(paste0("http://", host, ":", port)),
       error = function(err) {
-        warning("Could not open browser due to error in `utils::browseURL()`: ", conditionMessage(err))
+        message("Could not open browser due to error in `utils::browseURL()`: ", conditionMessage(err))
       }
     )
   }

--- a/R/staticServer.R
+++ b/R/staticServer.R
@@ -69,7 +69,12 @@ runStaticServer <- function(
   message("View at: http://", host, ":", port, sep = "")
 
   if (isTRUE(browse)) {
-    utils::browseURL(paste0("http://", host, ":", port))
+    tryCatch(
+      utils::browseURL(paste0("http://", host, ":", port)),
+      error = function(err) {
+        warning("Could not open browser due to error in `utils::browseURL()`: ", conditionMessage(err))
+      }
+    )
   }
 
   if (isTRUE(background)) {


### PR DESCRIPTION
Encountered in #393

## Before

```r
library(httpuv)
options(browser = character())

runStaticServer(
  system.file("example-static-site", package = "httpuv"),
  browse = TRUE
)
#> Serving: '/Users/garrick/Library/R/arm64/4.3/library/httpuv/example-static-site'
#> View at: http://127.0.0.1:7446
#> Error in utils::browseURL(paste0("http://", host, ":", port)): 'browser' must be a non-empty character string
```

## After

```r
library(httpuv)
options(browser = character())

s <- runStaticServer(
  system.file("example-static-site", package = "httpuv"),
  browse = TRUE,
  background = TRUE
)
#> Serving: '/Users/garrick/work/rstudio/httpuv/inst/example-static-site'
#> View at: http://127.0.0.1:34950
#> Could not open browser due to error in `utils::browseURL()`: 'browser' must be a non-empty character string
s$stop()
```