### PR TITLE
test(runStaticServer): Improve testing failure when port is in use

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `runStaticServer()` no longer fails if `browse = TRUE` but `utils::browseURL()` is unable to open the server. (#395)
 
+* Improved testing of `runStaticServer()` to accurately test that `runStaticServer()` throws an error when a requested port is not available on FreeBSD. (#396)
+
 # httpuv 1.6.14
 
 * Updated Makevars.ucrt for upcoming release of Rtools (thanks to Tomas Kalibera).

--- a/tests/testthat/test-staticServer.R
+++ b/tests/testthat/test-staticServer.R
@@ -73,16 +73,10 @@ test_that("runStaticServer() throws an error for invalid ports", {
 test_that("runStaticServer() throws an error if the requested port is used", {
   on.exit({ stopAllServers() }) # in case of a test failure
 
-  find_unsafe_port <- function() {
-    for (port in unsafe_ports) {
-      if (!is_port_available(port)) {
-        return(port)
-      }
-    }
-  }
+  s1 <- runStaticServer(path_example_site(), background = TRUE, browse = FALSE)
 
   expect_error(
-    runStaticServer(path_example_site(), port = find_unsafe_port(), background = TRUE)
+    runStaticServer(path_example_site(), port = s1$getPort(), background = TRUE, browse = FALSE)
   )
 })
 


### PR DESCRIPTION
Fixes #393

This PR updates a test for `runStaticServer()` that ensures it throws an error if the user requests a port that is already in use (as opposed to finding an unsued port, which is what happens if the user doesn't have a port preference).

To test this, we previously found an unsafe and used port, but in certain environments all of the unsafe ports are available (e.g. in freebsd jail). Rather than using the unsafe ports list, this test now starts up a static server and then tries to start a second static server using the same port.

Does this change warrant a NEWS bullet?