### PR TITLE
Skip timing-sensitive tests on CRAN

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,4 +19,4 @@ jobs:
   R-CMD-check:
     uses: rstudio/shiny-workflows/.github/workflows/R-CMD-check.yaml@v1
     with:
-      ubuntu: "ubuntu-20.04 ubuntu-latest"
+      ubuntu: "ubuntu-22.04 ubuntu-latest"

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Updated mime lookup table using mime R package 0.13. (#408)
 
+* Avoid some time-sensitive tests on CRAN. (#412)
+
 # httpuv 1.6.15
 
 * `runStaticServer()` no longer fails if `browse = TRUE` but `utils::browseURL()` is unable to open the server. (#395)

--- a/tests/testthat/test-static-server.R
+++ b/tests/testthat/test-static-server.R
@@ -1,3 +1,8 @@
+context("static-server")
+
+# These tests are time-sensitive, which makes CRAN unhappy.
+skip_on_cran()
+
 path_example_site <- function(...) {
   system.file("example-static-site", ..., package = "httpuv")
 }


### PR DESCRIPTION
Some tests are sensitive to timing, which can be problematic on the CRAN tests servers.

It also updates the test platform from Ubuntu 20.04 to 22.04, because the 20.04 runners will be completely unsupported as of tomorrow, 2025-04-15.