### PR TITLE
chore(test): Fix broken test for `mtime`

### DIFF
--- a/tests/testthat/test-static-paths.R
+++ b/tests/testthat/test-static-paths.R
@@ -700,7 +700,7 @@ test_that("Last-Modified and If-Modified-Since headers", {
   r <- fetch(local_url("/mtcars.csv", s$getPort()))
   h <- parse_headers_list(r$headers)
   http_mtime <- r$modified
-  expect_equal(file_mtime, http_mtime)
+  expect_equal(as.character(file_mtime), as.character(http_mtime))
 
 
   # Use the Last-Modified value in the If-Modified-Since header.


### PR DESCRIPTION
> ```
> Failure (test-static-paths.R:761:3): Last-Modified and If-Modified-Since headers
> `file_mtime` (`actual`) not equal to `http_mtime` (`expected`).
> 
> `attr(actual, 'tzone')` is a character vector ('America/New_York')
> `attr(expected, 'tzone')` is absent
> ```