### PR TITLE
fix: Skip tests if suggested packages aren't available

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -76,7 +76,7 @@ Config/testthat/edition: 3
 Config/usethis/last-upkeep: 2025-07-01
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 SystemRequirements: GNU make, zlib
 Collate:
     'RcppExports.R'

--- a/man/runStaticServer.Rd
+++ b/man/runStaticServer.Rd
@@ -72,7 +72,7 @@ When \code{background = TRUE}, the \code{server} object is returned invisibly.
 a single static directory, either in the foreground or the background.
 }
 \examples{
-\dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
 website_dir <- system.file("example-static-site", package = "httpuv")
 runStaticServer(dir = website_dir)
 \dontshow{\}) # examplesIf}

--- a/tests/testthat/helper-app.R
+++ b/tests/testthat/helper-app.R
@@ -1,6 +1,3 @@
-if (requireNamespace("curl", quietly = TRUE)) {
-  library(curl)
-}
 library(promises)
 
 
@@ -8,10 +5,10 @@ curl_fetch_async <- function(
   url,
   pool = NULL,
   data = NULL,
-  handle = new_handle()
+  handle = curl::new_handle()
 ) {
   p <- promises::promise(function(resolve, reject) {
-    curl_fetch_multi(
+    curl::curl_fetch_multi(
       url,
       done = resolve,
       fail = reject,
@@ -24,7 +21,7 @@ curl_fetch_async <- function(
   finished <- FALSE
   poll <- function() {
     if (!finished) {
-      multi_run(timeout = 0, poll = TRUE, pool = pool)
+      curl::multi_run(timeout = 0, poll = TRUE, pool = pool)
       later::later(poll, 0.01)
     }
   }
@@ -100,7 +97,7 @@ fetch <- function(url, handle = curl::new_handle(), gzip = TRUE) {
   if (!gzip) {
     # Disable gzip; this is often needed only because the unit tests predate
     # gzip support in httpuv
-    handle_setopt(handle, accept_encoding = NULL)
+    curl::handle_setopt(handle, accept_encoding = NULL)
   }
 
   p <- curl_fetch_async(url, handle = handle)

--- a/tests/testthat/helper-app.R
+++ b/tests/testthat/helper-app.R
@@ -1,4 +1,6 @@
-library(curl)
+if (requireNamespace("curl", quietly = TRUE)) {
+  library(curl)
+}
 library(promises)
 
 

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -1,4 +1,5 @@
 skip_if_not_installed("curl")
+library(curl)
 
 test_that("Basic functionality", {
   s1 <- startServer(

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -1,3 +1,5 @@
+skip_if_not_installed("curl")
+
 test_that("Basic functionality", {
   s1 <- startServer(
     "127.0.0.1",

--- a/tests/testthat/test-frame-completion.R
+++ b/tests/testthat/test-frame-completion.R
@@ -1,6 +1,8 @@
 # Regression test of
 # https://github.com/rstudio/httpuv/pull/219
 
+skip_if_not_installed("websocket")
+
 test_that("a close message with no payload is processed", {
   # Timing on CRAN build machines can be unreliable.
   skip_on_cran()

--- a/tests/testthat/test-http-parse.R
+++ b/tests/testthat/test-http-parse.R
@@ -1,3 +1,5 @@
+skip_if_not_installed("curl")
+
 test_that("Large HTTP header values are preserved", {
   # This is a test for https://github.com/rstudio/httpuv/issues/275
   # When there is a very large header, it may span multiple TCP messages.

--- a/tests/testthat/test-http-parse.R
+++ b/tests/testthat/test-http-parse.R
@@ -1,4 +1,5 @@
 skip_if_not_installed("curl")
+library(curl)
 
 test_that("Large HTTP header values are preserved", {
   # This is a test for https://github.com/rstudio/httpuv/issues/275

--- a/tests/testthat/test-static-paths.R
+++ b/tests/testthat/test-static-paths.R
@@ -1,4 +1,5 @@
 skip_if_not_installed("curl")
+library(curl)
 
 index_file_content <- raw_file_content(test_path("apps/content/index.html"))
 data_file_content <- raw_file_content(test_path("apps/content/data.txt"))

--- a/tests/testthat/test-static-paths.R
+++ b/tests/testthat/test-static-paths.R
@@ -1,3 +1,5 @@
+skip_if_not_installed("curl")
+
 index_file_content <- raw_file_content(test_path("apps/content/index.html"))
 data_file_content <- raw_file_content(test_path("apps/content/data.txt"))
 subdir_index_file_content <- raw_file_content(test_path(

--- a/tests/testthat/test-static-server.R
+++ b/tests/testthat/test-static-server.R
@@ -1,5 +1,6 @@
 # These tests are time-sensitive, which makes CRAN unhappy.
 skip_on_cran()
+skip_if_not_installed("curl")
 
 path_example_site <- function(...) {
   system.file("example-static-site", ..., package = "httpuv")

--- a/tests/testthat/test-static-server.R
+++ b/tests/testthat/test-static-server.R
@@ -1,6 +1,7 @@
 # These tests are time-sensitive, which makes CRAN unhappy.
 skip_on_cran()
 skip_if_not_installed("curl")
+library(curl)
 
 path_example_site <- function(...) {
   system.file("example-static-site", ..., package = "httpuv")


### PR DESCRIPTION
## Summary

- `curl` is in `Suggests`, but `library(curl)` was called unconditionally in `tests/testthat/helper-app.R`, causing the entire test suite to fail when curl is not available (e.g. in the `check-depends-only` CI job)
- The helper now loads curl conditionally with `requireNamespace()`
- The 4 test files that depend on curl (`test-app`, `test-http-parse`, `test-static-paths`, `test-static-server`) skip when curl is not installed
- The remaining 3 test files (`test-utils`, `test-traffic`, `test-frame-completion`) run regardless

## Test plan

- [ ] CI `check-depends-only` job passes
- [ ] All other CI jobs maintain the same pass/skip/fail counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)