### PR TITLE
fix: Suppress obsolete -single_module linker warning on macOS

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -65,7 +65,7 @@ libuv/Makefile: libuv/m4/lt~obsolete.m4
 	touch aclocal.m4 configure.ac Makefile.am m4/*.m4; \
 	touch -r aclocal.m4 configure Makefile.in; \
 	chmod +x configure; \
-	CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(C_VISIBILITY) -DNDEBUG" CPPFLAGS="$(CPPFLAGS)" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure $(CONFIGURE_FLAGS)
+	CC="$(CC)" CFLAGS="$(CFLAGS) $(CPICFLAGS) $(C_VISIBILITY) -DNDEBUG" CPPFLAGS="$(CPPFLAGS)" AR="$(AR)" RANLIB="$(RANLIB)" LDFLAGS="$(LDFLAGS)" ./configure lt_cv_apple_cc_single_mod=no $(CONFIGURE_FLAGS)
 
 libuv/.libs/libuv.b: libuv/Makefile
 	$(MAKE) --directory=libuv \


### PR DESCRIPTION
## Summary

Fixes a WARNING from `R CMD check` on newer macOS toolchains (Apple clang 21+, SDK 26.4+), as seen [on Brian Ripley's M1 Mac CRAN check machine](https://www.stats.ox.ac.uk/pub/bdr/M1mac/httpuv.out):

```
* checking whether package 'httpuv' can be installed ... [75s/89s] WARNING
Found the following significant warnings:
  ld: warning: -single_module is obsolete
```

## Root cause

libuv's bundled `configure` script (via libtool) probes for `-single_module` linker flag support by compiling a test program with `-Wl,-single_module`. On newer macOS, the linker accepts the flag but emits `ld: warning: -single_module is obsolete`. The configure script actually handles this correctly — it greps stderr for "single_module" and sets `lt_cv_apple_cc_single_mod=no`. But the `grep` command itself prints the matched line to stdout, which leaks into `00install.out` and gets flagged by `R CMD check` as a significant warning.

## Fix

Pre-set `lt_cv_apple_cc_single_mod=no` on the libuv configure command line. This causes configure to use the cached value and skip the probe entirely, so the problematic linker invocation never happens.

This is safe because:
- It's the same value configure would arrive at on affected systems (the probe detects the warning and sets it to `no` anyway)
- On older macOS, `-single_module` has been the default linker behavior for years, so omitting the flag is a no-op
- Pre-setting autoconf cache variables is a standard, well-documented technique for working around configure probes

## Test plan

- [x] Clean `R CMD INSTALL` with `USE_BUNDLED_LIBUV=true` succeeds
- [x] `R CMD check` passes with `Status: OK` (no WARNING)
- [x] Verified `single_module` does not appear in `00install.out`

🤖 Generated with [Claude Code](https://claude.com/claude-code)